### PR TITLE
css selector walk util

### DIFF
--- a/packages/css-selector-parser/src/ast-utils.ts
+++ b/packages/css-selector-parser/src/ast-utils.ts
@@ -10,13 +10,14 @@ export function walk(
   visit: (node: SelectorNode, parents: SelectorNode[]) => number | undefined,
   options: WalkOptions = {}
 ): void {
-  const parents: SelectorNode[] = [];
+  const parents: SelectorNode[][] = [[]];
   const toVisit: Array<SelectorNode | SelectorList | typeof nestEnd> = [
     current,
   ];
   let skipAmount = -1;
   while (toVisit.length) {
     const current = toVisit.shift()!;
+    const currentParents = parents[parents.length - 1];
     // visit only allowed nodes (also skip selector list)
     if (current === nestEnd) {
       parents.pop();
@@ -26,7 +27,7 @@ export function walk(
       (!options.ignoreList || !options.ignoreList.includes(current.type)) &&
       (!options.visitList || options.visitList.includes(current.type))
     ) {
-      skipAmount = visit(current, parents) ?? -1;
+      skipAmount = visit(current, currentParents) ?? -1;
     }
     if (skipAmount === Infinity) {
       // stop all: fast bail out
@@ -46,7 +47,7 @@ export function walk(
         toVisit.push(...current);
       } else if (isWithNodes(current)) {
         // add nested nodes
-        parents.push(current);
+        parents.push([...currentParents, current]);
         toVisit.unshift(...current.nodes, nestEnd);
       }
     }

--- a/packages/css-selector-parser/src/ast-utils.ts
+++ b/packages/css-selector-parser/src/ast-utils.ts
@@ -1,4 +1,4 @@
-import type { SelectorNode, SelectorList } from "./ast-types";
+import type { SelectorNode, SelectorList, Containers } from "./ast-types";
 
 export interface WalkOptions {
   visitList?: SelectorNode["type"][];
@@ -6,58 +6,112 @@ export interface WalkOptions {
 }
 const nestEnd = Symbol(`nest-end`);
 export function walk(
-  current: SelectorNode | SelectorList,
-  visit: (node: SelectorNode, parents: SelectorNode[]) => number | undefined,
+  topNode: SelectorNode | SelectorList,
+  visit: (
+    node: SelectorNode,
+    index: number,
+    nodes: SelectorNode[],
+    parents: SelectorNode[]
+  ) => number | undefined,
   options: WalkOptions = {}
 ): void {
-  const parents: SelectorNode[][] = [[]];
-  const toVisit: Array<SelectorNode | SelectorList | typeof nestEnd> = [
-    current,
-  ];
+  // set initial top nodes to traverse
+  const toVisit: Array<SelectorNode | typeof nestEnd> = Array.isArray(topNode)
+    ? [...topNode]
+    : [topNode];
+  // initiate context
+  const context = createWalkContext(topNode);
   let skipAmount = -1;
+  // iterate nodes
   while (toVisit.length) {
     const current = toVisit.shift()!;
-    const currentParents = parents[parents.length - 1];
-    // visit only allowed nodes (also skip selector list)
     if (current === nestEnd) {
-      parents.pop();
+      // end of nested level
+      context.up();
       continue;
     } else if (
-      !Array.isArray(current) &&
       (!options.ignoreList || !options.ignoreList.includes(current.type)) &&
       (!options.visitList || options.visitList.includes(current.type))
     ) {
-      skipAmount = visit(current, currentParents) ?? -1;
+      // visit node
+      skipAmount =
+        visit(
+          current,
+          context.indexInSelector,
+          context.nodesInSelector,
+          context.parents
+        ) ?? -1;
+      context.next();
     }
+    // setup before next iteration
     if (skipAmount === Infinity) {
       // stop all: fast bail out
       return;
     } else if (skipAmount >= 0) {
-      // skip next levels
+      // skip levels
       while (skipAmount > 0 && toVisit.length) {
         const next = toVisit.shift()!;
         if (next === nestEnd) {
           skipAmount--;
+          context.up();
         }
       }
-    } else {
-      // add nested
-      if (Array.isArray(current)) {
-        // add sub selectors
-        toVisit.push(...current);
-      } else if (isWithNodes(current)) {
-        // add nested nodes
-        parents.push([...currentParents, current]);
-        toVisit.unshift(...current.nodes, nestEnd);
-      }
+    } else if (isWithNodes(current)) {
+      // set context for nested nodes
+      context.insertNested(current);
+      // add nested to visit list
+      toVisit.unshift(...current.nodes, nestEnd);
     }
   }
+}
+
+interface WalkContext {
+  parents: SelectorNode[];
+  indexInSelector: number;
+  nodesInSelector: SelectorNode[];
+  up(): void;
+  next(): void;
+  insertNested(node: ContainerWithNodes): void;
+}
+function createWalkContext(topNode: SelectorNode | SelectorList) {
+  const prevIndex: number[] = [];
+  const prevParents: SelectorNode[][] = [[]];
+  const context: WalkContext = {
+    parents: [],
+    indexInSelector: 0,
+    nodesInSelector: Array.isArray(topNode)
+      ? topNode
+      : `nodes` in topNode
+      ? topNode.nodes!
+      : [topNode],
+    up() {
+      context.parents.pop();
+      context.indexInSelector = prevIndex.shift()!;
+      const currentParents = context.parents;
+      const currentParent = currentParents[currentParents.length - 1];
+      context.nodesInSelector = currentParent
+        ? (currentParent as any).nodes
+        : topNode;
+    },
+    next() {
+      context.indexInSelector++;
+    },
+    insertNested(node) {
+      context.parents = [...context.parents, node];
+      prevParents.push(context.parents);
+      prevIndex.unshift(context.indexInSelector);
+      context.indexInSelector = 0;
+      context.nodesInSelector = node.nodes;
+    },
+  };
+  return context;
 }
 
 walk.skipNested = 0 as const;
 walk.skipCurrentSelector = 1 as const;
 walk.stopAll = Infinity;
 
-function isWithNodes(node: any): node is { nodes: SelectorNode[] } {
+type ContainerWithNodes = Containers & { nodes: SelectorNode[] };
+function isWithNodes(node: any): node is ContainerWithNodes {
   return node && `nodes` in node;
 }

--- a/packages/css-selector-parser/src/ast-utils.ts
+++ b/packages/css-selector-parser/src/ast-utils.ts
@@ -1,0 +1,48 @@
+import type { SelectorNode, SelectorList } from "./ast-types";
+
+export interface WalkOptions {
+  visitList?: SelectorNode["type"][];
+  ignoreList?: SelectorNode["type"][];
+}
+export function walk(
+  current: SelectorNode | SelectorList,
+  visit: (node: SelectorNode) => number | undefined,
+  options: WalkOptions = {}
+): number | undefined {
+  // visit only allowed nodes (also skip selector list)
+  if (
+    !Array.isArray(current) &&
+    (!options.ignoreList || !options.ignoreList.includes(current.type)) &&
+    (!options.visitList || options.visitList.includes(current.type))
+  ) {
+    const skipAmount = visit(current);
+    if (skipAmount !== undefined) {
+      // stop
+      return skipAmount > 0 ? skipAmount - 1 : undefined;
+    }
+  }
+  // iterate nested nodes
+  const nodes = Array.isArray(current)
+    ? current
+    : isWithNodes(current)
+    ? current.nodes
+    : null;
+  if (nodes) {
+    for (const node of nodes) {
+      const skipAmount = walk(node, visit, options);
+      if (skipAmount !== undefined) {
+        // stop
+        return skipAmount > 0 ? skipAmount - 1 : undefined;
+      }
+    }
+  }
+  return;
+}
+
+walk.skipNested = 0 as const;
+walk.skipCurrentSelector = 1 as const;
+walk.stopAll = Infinity;
+
+function isWithNodes(node: any): node is { nodes: SelectorNode[] } {
+  return node && `nodes` in node;
+}

--- a/packages/css-selector-parser/src/helpers.ts
+++ b/packages/css-selector-parser/src/helpers.ts
@@ -91,20 +91,6 @@ export function isNamespacedAst(token: SelectorNode): token is NamespacedNodes {
 
 // utils
 
-export function traverse(
-  node: SelectorNode,
-  visit: (node: SelectorNode, ctx: {}) => boolean | void,
-  ctx?: {}
-) {
-  ctx = ctx || {};
-  const r = visit(node, ctx) ?? 3;
-  if (r !== false && "nodes" in node && node.nodes) {
-    for (const child of node.nodes) {
-      traverse(child, visit, ctx);
-    }
-  }
-}
-
 export function ensureSelector(
   selectors: SelectorList,
   startToken: CSSSelectorToken

--- a/packages/css-selector-parser/src/index.ts
+++ b/packages/css-selector-parser/src/index.ts
@@ -1,3 +1,4 @@
 export { parseCssSelector } from "./selector-parser";
 export * from "./ast-types";
 export { stringifySelectorAst } from "./stringify";
+export { walk, WalkOptions } from "./ast-utils";

--- a/packages/css-selector-parser/test/ast-utils.spec.ts
+++ b/packages/css-selector-parser/test/ast-utils.spec.ts
@@ -1,0 +1,214 @@
+import {
+  parseCssSelector,
+  walk,
+  WalkOptions,
+  SelectorNode,
+  SelectorList,
+} from "@tokey/css-selector-parser";
+import { isMatch } from "@tokey/test-kit";
+
+function testWalk(
+  topNode: SelectorNode | SelectorList,
+  {
+    walkOptions,
+    mapVisit,
+    resultVisit,
+    expectedMap,
+  }: {
+    walkOptions?: WalkOptions;
+    mapVisit: (node: SelectorNode) => any;
+    resultVisit?: (node: SelectorNode) => number | undefined;
+    expectedMap: any[];
+  }
+) {
+  const actual: any[] = [];
+  try {
+    walk(
+      topNode,
+      (current: SelectorNode) => {
+        actual.push(mapVisit ? mapVisit(current) : current);
+        return resultVisit ? resultVisit(current) : undefined;
+      },
+      walkOptions
+    );
+  } catch (e) {
+    throw new Error(`error in walk, ${e}`);
+  }
+  if (!isMatch(actual, expectedMap)) {
+    const e = JSON.stringify(expectedMap, null, 2);
+    const a = JSON.stringify(actual, null, 2);
+    throw new Error(`Fail walk: \n${a}\nTo\n${e}`);
+  }
+}
+
+describe(`ast-utils`, () => {
+  describe(`walk`, () => {
+    it(`should visit nodes`, () => {
+      testWalk(parseCssSelector(`.a#b`), {
+        mapVisit: ({ type, value }: any) => ({ type, value }),
+        expectedMap: [
+          { type: `selector`, value: undefined },
+          { type: `class`, value: `a` },
+          { type: `id`, value: `b` },
+        ],
+      });
+    });
+    it(`should not visit specified types`, () => {
+      testWalk(parseCssSelector(`.a#b.c`), {
+        walkOptions: {
+          ignoreList: ["selector", `id`],
+        },
+        mapVisit: ({ type, value }: any) => ({ type, value }),
+        expectedMap: [
+          { type: `class`, value: `a` },
+          { type: `class`, value: `c` },
+        ],
+      });
+    });
+    it(`should visit only specified types`, () => {
+      testWalk(parseCssSelector(`.a#b.c #d`), {
+        walkOptions: {
+          visitList: [`id`],
+        },
+        mapVisit: ({ type, value }: any) => ({ type, value }),
+        expectedMap: [
+          { type: `id`, value: `b` },
+          { type: `id`, value: `d` },
+        ],
+      });
+    });
+    it(`should visit combinators`, () => {
+      testWalk(parseCssSelector(`.a + .b`), {
+        mapVisit: ({ type, value }: any) => ({ type, value }),
+        expectedMap: [
+          { type: `selector`, value: undefined },
+          { type: `class`, value: `a` },
+          { type: `combinator`, value: `+` },
+          { type: `class`, value: `b` },
+        ],
+      });
+    });
+    it(`should visit all basic selector types`, () => {
+      testWalk(parseCssSelector(`*.a + :b > ::c ~ #d[e] /*f*/`), {
+        walkOptions: {
+          ignoreList: [`selector`],
+        },
+        mapVisit: ({ type, value }: any) => ({ type, value }),
+        expectedMap: [
+          { type: `star`, value: `*` },
+          { type: `class`, value: `a` },
+          { type: `combinator`, value: `+` },
+          { type: `pseudo_class`, value: `b` },
+          { type: `combinator`, value: `>` },
+          { type: `pseudo_element`, value: `c` },
+          { type: `combinator`, value: `~` },
+          { type: `id`, value: `d` },
+          { type: `attribute`, value: `e` },
+          { type: `comment`, value: `/*f*/` },
+        ],
+      });
+    });
+    it(`should visit nested`, () => {
+      testWalk(parseCssSelector(`:a(::b(.c(d(x))), y) + z`), {
+        mapVisit: ({ type, value }: any) => ({ type, value }),
+        expectedMap: [
+          { type: `selector`, value: undefined },
+          { type: `pseudo_class`, value: `a` },
+          { type: `selector`, value: undefined },
+          { type: `pseudo_element`, value: `b` },
+          { type: `selector`, value: undefined },
+          { type: `class`, value: `c` },
+          { type: `selector`, value: undefined },
+          { type: `element`, value: `d` },
+          { type: `selector`, value: undefined },
+          { type: `element`, value: `x` },
+          { type: `selector`, value: undefined },
+          { type: `element`, value: `y` },
+          { type: `combinator`, value: `+` },
+          { type: `element`, value: `z` },
+        ],
+      });
+    });
+    it(`should skip nested (return 0)`, () => {
+      testWalk(parseCssSelector(`:is(:skip-nested(.a).b, .c).d, .e`), {
+        mapVisit: ({ type, value }: any) => ({ type, value }),
+        resultVisit: ({ value }: any) =>
+          value === `skip-nested` ? walk.skipNested : undefined,
+        expectedMap: [
+          { type: `selector`, value: undefined },
+          { type: `pseudo_class`, value: `is` },
+          { type: `selector`, value: undefined },
+          { type: `pseudo_class`, value: `skip-nested` },
+          { type: `class`, value: `b` },
+          { type: `selector`, value: undefined },
+          { type: `class`, value: `c` },
+          { type: `class`, value: `d` },
+          { type: `selector`, value: undefined },
+          { type: `class`, value: `e` },
+        ],
+      });
+    });
+    it(`should skip current selector`, () => {
+      testWalk(parseCssSelector(`:is(:skip-selector(.a).b, .c).d, .e`), {
+        mapVisit: ({ type, value }: any) => ({ type, value }),
+        resultVisit: ({ value }: any) =>
+          value === `skip-selector` ? walk.skipCurrentSelector : undefined,
+        expectedMap: [
+          { type: `selector`, value: undefined },
+          { type: `pseudo_class`, value: `is` },
+          { type: `selector`, value: undefined },
+          { type: `pseudo_class`, value: `skip-selector` },
+          { type: `selector`, value: undefined },
+          { type: `class`, value: `c` },
+          { type: `class`, value: `d` },
+          { type: `selector`, value: undefined },
+          { type: `class`, value: `e` },
+        ],
+      });
+    });
+    it(`should stop walk completely`, () => {
+      testWalk(parseCssSelector(`:is(:stop(.a).b, .c).d, .e`), {
+        mapVisit: ({ type, value }: any) => ({ type, value }),
+        resultVisit: ({ value }: any) =>
+          value === `stop` ? walk.stopAll : undefined,
+        expectedMap: [
+          { type: `selector`, value: undefined },
+          { type: `pseudo_class`, value: `is` },
+          { type: `selector`, value: undefined },
+          { type: `pseudo_class`, value: `stop` },
+        ],
+      });
+    });
+    it(`skip X levels down (2)`, () => {
+      testWalk(parseCssSelector(`:is(:skip-2-levels(.a).b, .c).d, .e`), {
+        mapVisit: ({ type, value }: any) => ({ type, value }),
+        resultVisit: ({ value }: any) =>
+          value === `skip-2-levels` ? 2 : undefined,
+        expectedMap: [
+          { type: `selector`, value: undefined },
+          { type: `pseudo_class`, value: `is` },
+          { type: `selector`, value: undefined },
+          { type: `pseudo_class`, value: `skip-2-levels` },
+          { type: `class`, value: `d` },
+          { type: `selector`, value: undefined },
+          { type: `class`, value: `e` },
+        ],
+      });
+    });
+    it(`skip X levels down through selectors (3)`, () => {
+      testWalk(parseCssSelector(`:is(:skip-3-levels(.a).b, .c).d, .e`), {
+        mapVisit: ({ type, value }: any) => ({ type, value }),
+        resultVisit: ({ value }: any) =>
+          value === `skip-3-levels` ? 3 : undefined,
+        expectedMap: [
+          { type: `selector`, value: undefined },
+          { type: `pseudo_class`, value: `is` },
+          { type: `selector`, value: undefined },
+          { type: `pseudo_class`, value: `skip-3-levels` },
+          { type: `selector`, value: undefined },
+          { type: `class`, value: `e` },
+        ],
+      });
+    });
+  });
+});

--- a/packages/css-selector-parser/test/ast-utils.spec.ts
+++ b/packages/css-selector-parser/test/ast-utils.spec.ts
@@ -16,9 +16,16 @@ function testWalk(
     expectedMap,
   }: {
     walkOptions?: WalkOptions;
-    mapVisit: (node: SelectorNode, parents: SelectorNode[]) => any;
+    mapVisit: (
+      node: SelectorNode,
+      index: number,
+      nodes: SelectorNode[],
+      parents: SelectorNode[]
+    ) => any;
     resultVisit?: (
       node: SelectorNode,
+      index: number,
+      nodes: SelectorNode[],
       parents: SelectorNode[]
     ) => number | undefined;
     expectedMap: any[];
@@ -28,9 +35,18 @@ function testWalk(
   try {
     walk(
       topNode,
-      (current: SelectorNode, parents: SelectorNode[]) => {
-        actual.push(mapVisit ? mapVisit(current, parents) : current);
-        return resultVisit ? resultVisit(current, parents) : undefined;
+      (
+        current: SelectorNode,
+        index: number,
+        nodes: SelectorNode[],
+        parents: SelectorNode[]
+      ) => {
+        actual.push(
+          mapVisit ? mapVisit(current, index, nodes, parents) : current
+        );
+        return resultVisit
+          ? resultVisit(current, index, nodes, parents)
+          : undefined;
       },
       walkOptions
     );
@@ -213,48 +229,215 @@ describe(`ast-utils`, () => {
         ],
       });
     });
-    it(`should provide parent list to visit`, () => {
-      testWalk(parseCssSelector(`:a(:b(:c))`), {
-        mapVisit: ({ type, value }: any, parents: any[]) => ({
-          type,
-          value,
-          parents: parents.map(({ value, type }) => value || type).join(`,`),
-        }),
-        expectedMap: [
-          { type: `selector`, value: undefined, parents: `` },
-          { type: `pseudo_class`, value: `a`, parents: `selector` },
-          { type: `selector`, value: undefined, parents: `selector,a` },
-          { type: `pseudo_class`, value: `b`, parents: `selector,a,selector` },
-          {
-            type: `selector`,
-            value: undefined,
-            parents: `selector,a,selector,b`,
-          },
-          {
-            type: `pseudo_class`,
-            value: `c`,
-            parents: `selector,a,selector,b,selector`,
-          },
-        ],
+    describe(`context`, () => {
+      it(`should provide index and sibling nodes within selector`, () => {
+        testWalk(parseCssSelector(`:a(.a1.a2, .aX.aY), :b(.b1.b2)`), {
+          mapVisit: ({ type, value }: any, index: number, nodes: any[]) => ({
+            type,
+            value,
+            index,
+            nodes: nodes.map(({ value, type }) => value || type).join(`,`),
+          }),
+          expectedMap: [
+            {
+              type: `selector`,
+              value: undefined,
+              index: 0,
+              nodes: `selector,selector`,
+            },
+            { type: `pseudo_class`, value: `a`, index: 0, nodes: `a` },
+            {
+              type: `selector`,
+              value: undefined,
+              index: 0,
+              nodes: `selector,selector`,
+            },
+            {
+              type: `class`,
+              value: `a1`,
+              index: 0,
+              nodes: `a1,a2`,
+            },
+            {
+              type: `class`,
+              value: `a2`,
+              index: 1,
+              nodes: `a1,a2`,
+            },
+            {
+              type: `selector`,
+              value: undefined,
+              index: 1,
+              nodes: `selector,selector`,
+            },
+            {
+              type: `class`,
+              value: `aX`,
+              index: 0,
+              nodes: `aX,aY`,
+            },
+            {
+              type: `class`,
+              value: `aY`,
+              index: 1,
+              nodes: `aX,aY`,
+            },
+            {
+              type: `selector`,
+              value: undefined,
+              index: 1,
+              nodes: `selector,selector`,
+            },
+            { type: `pseudo_class`, value: `b`, index: 0, nodes: `b` },
+            { type: `selector`, value: undefined, index: 0, nodes: `selector` },
+            {
+              type: `class`,
+              value: `b1`,
+              index: 0,
+              nodes: `b1,b2`,
+            },
+            {
+              type: `class`,
+              value: `b2`,
+              index: 1,
+              nodes: `b1,b2`,
+            },
+          ],
+        });
       });
-    });
-    it(`should provide parent list to visit (test multi selectors)`, () => {
-      testWalk(parseCssSelector(`:a(:a1(), :a2), :b(:b1)`), {
-        walkOptions: {
-          ignoreList: [`selector`],
-        },
-        mapVisit: ({ type, value }: any, parents: any[]) => ({
-          type,
-          value,
-          parents: parents.map(({ value, type }) => value || type).join(`,`),
-        }),
-        expectedMap: [
-          { type: `pseudo_class`, value: `a`, parents: `selector` },
-          { type: `pseudo_class`, value: `a1`, parents: `selector,a,selector` },
-          { type: `pseudo_class`, value: `a2`, parents: `selector,a,selector` },
-          { type: `pseudo_class`, value: `b`, parents: `selector` },
-          { type: `pseudo_class`, value: `b1`, parents: `selector,b,selector` },
-        ],
+      it(`should provide index and sibling nodes within selector (skip nodes)`, () => {
+        testWalk(parseCssSelector(`:a(.a1.a2, .aX.aY), :b(.b1.b2)`), {
+          mapVisit: ({ type, value }: any, index: number, nodes: any[]) => ({
+            type,
+            value,
+            index,
+            nodes: nodes.map(({ value, type }) => value || type).join(`,`),
+          }),
+          resultVisit: ({ value }: any) => {
+            if (value === `a1`) {
+              return walk.skipCurrentSelector;
+            } else if (value === `b`) {
+              return walk.skipNested;
+            }
+            return;
+          },
+          expectedMap: [
+            {
+              type: `selector`,
+              value: undefined,
+              index: 0,
+              nodes: `selector,selector`,
+            },
+            { type: `pseudo_class`, value: `a`, index: 0, nodes: `a` },
+            {
+              type: `selector`,
+              value: undefined,
+              index: 0,
+              nodes: `selector,selector`,
+            },
+            {
+              type: `class`,
+              value: `a1`,
+              index: 0,
+              nodes: `a1,a2`,
+            },
+            {
+              type: `selector`,
+              value: undefined,
+              index: 1,
+              nodes: `selector,selector`,
+            },
+            {
+              type: `class`,
+              value: `aX`,
+              index: 0,
+              nodes: `aX,aY`,
+            },
+            {
+              type: `class`,
+              value: `aY`,
+              index: 1,
+              nodes: `aX,aY`,
+            },
+            {
+              type: `selector`,
+              value: undefined,
+              index: 1,
+              nodes: `selector,selector`,
+            },
+            { type: `pseudo_class`, value: `b`, index: 0, nodes: `b` },
+          ],
+        });
+      });
+      it(`should provide parent list to visit`, () => {
+        testWalk(parseCssSelector(`:a(:b(:c))`), {
+          mapVisit: (
+            { type, value }: any,
+            _index: number,
+            _nodes: any[],
+            parents: any[]
+          ) => ({
+            type,
+            value,
+            parents: parents.map(({ value, type }) => value || type).join(`,`),
+          }),
+          expectedMap: [
+            { type: `selector`, value: undefined, parents: `` },
+            { type: `pseudo_class`, value: `a`, parents: `selector` },
+            { type: `selector`, value: undefined, parents: `selector,a` },
+            {
+              type: `pseudo_class`,
+              value: `b`,
+              parents: `selector,a,selector`,
+            },
+            {
+              type: `selector`,
+              value: undefined,
+              parents: `selector,a,selector,b`,
+            },
+            {
+              type: `pseudo_class`,
+              value: `c`,
+              parents: `selector,a,selector,b,selector`,
+            },
+          ],
+        });
+      });
+      it(`should provide parent list to visit (test multi selectors)`, () => {
+        testWalk(parseCssSelector(`:a(:a1(), :a2), :b(:b1)`), {
+          walkOptions: {
+            ignoreList: [`selector`],
+          },
+          mapVisit: (
+            { type, value }: any,
+            _index: number,
+            _nodes: any[],
+            parents: any[]
+          ) => ({
+            type,
+            value,
+            parents: parents.map(({ value, type }) => value || type).join(`,`),
+          }),
+          expectedMap: [
+            { type: `pseudo_class`, value: `a`, parents: `selector` },
+            {
+              type: `pseudo_class`,
+              value: `a1`,
+              parents: `selector,a,selector`,
+            },
+            {
+              type: `pseudo_class`,
+              value: `a2`,
+              parents: `selector,a,selector`,
+            },
+            { type: `pseudo_class`, value: `b`, parents: `selector` },
+            {
+              type: `pseudo_class`,
+              value: `b1`,
+              parents: `selector,b,selector`,
+            },
+          ],
+        });
       });
     });
   });

--- a/packages/css-selector-parser/test/ast-utils.spec.ts
+++ b/packages/css-selector-parser/test/ast-utils.spec.ts
@@ -179,7 +179,7 @@ describe(`ast-utils`, () => {
         ],
       });
     });
-    it(`skip X levels down (2)`, () => {
+    it(`should skip X levels down (2)`, () => {
       testWalk(parseCssSelector(`:is(:skip-2-levels(.a).b, .c).d, .e`), {
         mapVisit: ({ type, value }: any) => ({ type, value }),
         resultVisit: ({ value }: any) =>
@@ -195,7 +195,7 @@ describe(`ast-utils`, () => {
         ],
       });
     });
-    it(`skip X levels down through selectors (3)`, () => {
+    it(`should skip X levels down through selectors (3)`, () => {
       testWalk(parseCssSelector(`:is(:skip-3-levels(.a).b, .c).d, .e`), {
         mapVisit: ({ type, value }: any) => ({ type, value }),
         resultVisit: ({ value }: any) =>

--- a/packages/test-kit/src/index.ts
+++ b/packages/test-kit/src/index.ts
@@ -1,2 +1,3 @@
 export { createParseTester } from "./parse-tester";
 export { testTokenizer } from "./test-tokenizer";
+export { isMatch } from "./is-match";


### PR DESCRIPTION
This PR adds a util to `@tokey/css-selector-parser` that walks the ast.

- export `walk` function and `WalkOptions` type
- walk on every type of ast node
- limit/exclude ast visits by type
- stop walk after visit with options `walk.skipNested` / `walk.skipCurrentselector` / `walk.stopAll`
- provide parent list to walk visit

currently implemented a walk test util that could probably be generalized and used with other parsers ast. will wait for another parser to expose walk util before moving it to the test-kit.