### PR TITLE
css selector escaping support

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -2,8 +2,8 @@ import type { Token } from "./types";
 
 export interface TokyOptions<T extends Token<unknown>> {
   shouldAddToken(type: T["type"], value: string): boolean;
-  isStringDelimiter(char: string): boolean;
-  isDelimiter(char: string): boolean;
+  isStringDelimiter(char: string, previousChar: string): boolean;
+  isDelimiter(char: string, previousChar: string): boolean;
   isWhitespace(char: string): boolean;
   getCommentStartType(
     ch: string,
@@ -58,11 +58,11 @@ export function tokenize<T extends Token<unknown>>(
     } else if ((inComment = getCommentStartType(ch, source, nextCharIndex))) {
       pushBuffer();
       buffer += ch;
-    } else if (isStringDelimiter(ch)) {
+    } else if (isStringDelimiter(ch, previousChar)) {
       pushBuffer();
       buffer += ch;
       inString = ch;
-    } else if (isDelimiter(ch)) {
+    } else if (isDelimiter(ch, previousChar)) {
       pushBuffer();
       buffer += ch;
       pushBuffer(ch);

--- a/packages/core/test/core.spec.ts
+++ b/packages/core/test/core.spec.ts
@@ -43,6 +43,25 @@ const ignoreSpaceTokenizer = <T extends string>(input: T) =>
     },
   });
 
+const escapeTokenizer = <T extends string>(input: T) =>
+  tokenize(input, {
+    ...options,
+    isDelimiter(char: string, previousChar: string) {
+      return (
+        previousChar !== `\\` &&
+        (char === "(" ||
+          char === ")" ||
+          char === "{" ||
+          char === "}" ||
+          char === "[" ||
+          char === "]")
+      );
+    },
+    isStringDelimiter(char: string, previousChar: string) {
+      return previousChar !== `\\` && isStringDelimiter(char);
+    },
+  });
+
 describe("core - tokenize", () => {
   it("1", () => {
     test("1", defaultTokenizer, [
@@ -155,5 +174,21 @@ describe("core - tokenize", () => {
       { value: "1", type: "text", start: 0, end: 1 },
       { value: "2", type: "text", start: 2, end: 3 },
     ]);
+  });
+
+  describe(`escape`, () => {
+    it(`should ignore delimiter when previous char is escape string`, () => {
+      test(`tex\\(t`, escapeTokenizer, [
+        { value: "tex\\(t", type: "text", start: 0, end: 6 },
+      ]);
+    });
+    it(`should ignore string starter when previous char is escape string`, () => {
+      test(`tex\\"\\'t`, escapeTokenizer, [
+        { value: `tex\\"\\'t`, type: "text", start: 0, end: 8 },
+      ]);
+      test("tex\\`t", escapeTokenizer, [
+        { value: "tex\\`t", type: "text", start: 0, end: 6 },
+      ]);
+    });
   });
 });

--- a/packages/css-selector-parser/src/tokenizer.ts
+++ b/packages/css-selector-parser/src/tokenizer.ts
@@ -33,7 +33,9 @@ export function tokenizeSelector(source: string) {
   const parseLineComments = false; // why would that be a choice?
   return tokenize<CSSSelectorToken>(source, {
     isDelimiter,
-    isStringDelimiter,
+    isStringDelimiter(char: string, previousChar: string) {
+      return previousChar !== `\\` && isStringDelimiter(char);
+    },
     isWhitespace,
     shouldAddToken: () => true,
     createToken,
@@ -45,19 +47,20 @@ export function tokenizeSelector(source: string) {
   });
 }
 
-const isDelimiter = (char: string) =>
-  char === "[" ||
-  char === "]" ||
-  char === "(" ||
-  char === ")" ||
-  char === "," ||
-  char === "*" ||
-  char === "|" ||
-  char === ":" ||
-  char === "." ||
-  char === "#" ||
-  char === ">" ||
-  char === "~" ||
-  char === "+" ||
-  char === "{" ||
-  char === "}";
+const isDelimiter = (char: string, previousChar: string) =>
+  previousChar !== "\\" &&
+  (char === "[" ||
+    char === "]" ||
+    char === "(" ||
+    char === ")" ||
+    char === "," ||
+    char === "*" ||
+    char === "|" ||
+    char === ":" ||
+    char === "." ||
+    char === "#" ||
+    char === ">" ||
+    char === "~" ||
+    char === "+" ||
+    char === "{" ||
+    char === "}");

--- a/packages/css-selector-parser/test/selector-parser.spec.ts
+++ b/packages/css-selector-parser/test/selector-parser.spec.ts
@@ -3067,6 +3067,65 @@ describe(`selector-parser`, () => {
       });
     });
   });
+  describe(`escaped`, () => {
+    it(`should parse escaped delimiters as part of value`, () => {
+      test(`.classWith\\.dot`, {
+        expectedAst: [
+          createNode({
+            type: `selector`,
+            start: 0,
+            end: 15,
+            nodes: [
+              createNode({
+                type: `class`,
+                value: `classWith\\.dot`,
+                start: 0,
+                end: 15,
+              }),
+            ],
+          }),
+        ],
+      });
+    });
+    it(`should parse escaped delimiters (various)`, () => {
+      test(`.a\\.\\[\\]\\(\\)\\,\\*\\|\\:\\#\\>\\~\\+\\{\\}`, {
+        expectedAst: [
+          createNode({
+            type: `selector`,
+            start: 0,
+            end: 32,
+            nodes: [
+              createNode({
+                type: `class`,
+                value: `a\\.\\[\\]\\(\\)\\,\\*\\|\\:\\#\\>\\~\\+\\{\\}`,
+                start: 0,
+                end: 32,
+              }),
+            ],
+          }),
+        ],
+      });
+    });
+    it(`should parse escaped string delimiters as part of value`, () => {
+      test(`.a\\"\\'`, {
+        expectedAst: [
+          createNode({
+            type: `selector`,
+            start: 0,
+            end: 6,
+            nodes: [
+              createNode({
+                type: `class`,
+                value: `a\\"\\'`,
+                start: 0,
+                end: 6,
+              }),
+            ],
+          }),
+        ],
+      });
+    });
+  });
   describe(`combinations`, () => {
     it(`:a(.b,::d(.e,.f))`, () => {
       test(`:a(.b,::d(.e,.f))`, {


### PR DESCRIPTION
This PR adds the ability to support escaping of delimiters to tokey/core and uses that feature to support escaping in the css-selector-parser

jsbin with escaping examples: [link](https://jsbin.com/nitazujabi/edit?html,css,js,output)