### PR TITLE
support css selector nesting syntax

### DIFF
--- a/packages/css-selector-parser/src/ast-types.ts
+++ b/packages/css-selector-parser/src/ast-types.ts
@@ -57,6 +57,11 @@ export interface Combinator extends Token<"combinator"> {
   invalid: boolean;
 }
 
+export interface Nesting extends Token<"nesting"> {
+  value: "&";
+  nodes?: SelectorList;
+}
+
 export type Invalid = Token<"invalid">;
 export interface Comment extends Token<"comment"> {
   before: string;
@@ -88,7 +93,8 @@ export type Containers =
   | Id
   | Class
   | PseudoClass
-  | PseudoElement;
+  | PseudoElement
+  | Nesting;
 
 export type SelectorNode =
   | Containers

--- a/packages/css-selector-parser/src/selector-parser.ts
+++ b/packages/css-selector-parser/src/selector-parser.ts
@@ -399,6 +399,13 @@ function handleToken(
       newSelector.start = s.peek().start;
     }
     selectors.push(newSelector);
+  } else  if (token.type === "&") {
+    ast.push({
+      type: "nesting",
+      value: "&",
+      start: token.start,
+      end: token.end,
+    });
   } else {
     ast.push({
       type: "invalid",

--- a/packages/css-selector-parser/src/stringify.ts
+++ b/packages/css-selector-parser/src/stringify.ts
@@ -20,6 +20,7 @@ import type {
   SelectorList,
   SelectorNode,
   Star,
+  Nesting,
 } from "./ast-types";
 
 export function stringifySelectorAst(
@@ -55,6 +56,7 @@ const printers: R = {
   comment: ({ before, value, after }: Comment) => `${before}${value}${after}`,
   star: (node: Star) =>
     `${stringifyNamespace(node)}${node.value}${stringifyNested(node)}`,
+  nesting: (node: Nesting) => `${node.value}${stringifyNested(node)}`,
   selector: (node: Selector) =>
     `${node.before}${node.nodes.map(stringifyNode).join("")}${node.after}`,
   invalid: (node: Invalid) => node.value,

--- a/packages/css-selector-parser/src/tokenizer.ts
+++ b/packages/css-selector-parser/src/tokenizer.ts
@@ -25,7 +25,8 @@ type Delimiters =
   | "~"
   | "+"
   | "{"
-  | "}";
+  | "}"
+  | "&";
 
 export type CSSSelectorToken = Token<Descriptors | Delimiters>;
 
@@ -60,4 +61,5 @@ const isDelimiter = (char: string) =>
   char === "~" ||
   char === "+" ||
   char === "{" ||
-  char === "}";
+  char === "}" ||
+  char === "&";

--- a/packages/css-selector-parser/test/selector-parser.spec.ts
+++ b/packages/css-selector-parser/test/selector-parser.spec.ts
@@ -483,6 +483,31 @@ describe(`selector-parser`, () => {
         ],
       });
     });
+    it(`&&`, () => {
+      test(`&&`, {
+        expectedAst: [
+          createNode({
+            type: `selector`,
+            start: 0,
+            end: 2,
+            nodes: [
+              createNode({
+                type: `nesting`,
+                value: `&`,
+                start: 0,
+                end: 1,
+              }),
+              createNode({
+                type: `nesting`,
+                value: `&`,
+                start: 1,
+                end: 2,
+              }),
+            ],
+          }),
+        ],
+      });
+    });
   });
   describe(`nth`, () => {
     it(`:nth-child()`, () => {
@@ -1514,6 +1539,42 @@ describe(`selector-parser`, () => {
                   beforeComments: [],
                   afterComments: [],
                 },
+              }),
+            ],
+          }),
+        ],
+      });
+    });
+  });
+  describe(`nesting`, () => {
+    it(`&(:hover)`, () => {
+      test(`&(:hover)`, {
+        expectedAst: [
+          createNode({
+            type: `selector`,
+            start: 0,
+            end: 9,
+            nodes: [
+              createNode({
+                type: `nesting`,
+                value: `&`,
+                start: 0,
+                end: 9,
+                nodes: [
+                  createNode({
+                    type: `selector`,
+                    start: 2,
+                    end: 8,
+                    nodes: [
+                      createNode({
+                        type: `pseudo_class`,
+                        value: `hover`,
+                        start: 2,
+                        end: 8,
+                      }),
+                    ],
+                  }),
+                ],
               }),
             ],
           }),
@@ -2885,6 +2946,43 @@ describe(`selector-parser`, () => {
         ],
       });
     });
+    it(`&|&`, () => {
+      test(`&|&`, {
+        expectedAst: [
+          createNode({
+            type: `selector`,
+            start: 0,
+            end: 3,
+            nodes: [
+              createNode({
+                type: `nesting`,
+                value: `&`,
+                start: 0,
+                end: 1,
+              }),
+              createNode({
+                type: `element`,
+                value: ``,
+                start: 1,
+                end: 2,
+                namespace: {
+                  value: ``,
+                  invalid: `namespace,target`,
+                  beforeComments: [],
+                  afterComments: [],
+                },
+              }),
+              createNode({
+                type: `nesting`,
+                value: `&`,
+                start: 2,
+                end: 3,
+              }),
+            ],
+          }),
+        ],
+      });
+    });
   });
   describe(`spaces`, () => {
     it(`:p(  .a  ,   .b  )`, () => {
@@ -3201,6 +3299,37 @@ describe(`selector-parser`, () => {
                 value: `b`,
                 start: 5,
                 end: 7,
+              }),
+            ],
+          }),
+        ],
+      });
+    });
+    it(`.z&div`, () => {
+      test(`.z&div`, {
+        expectedAst: [
+          createNode({
+            type: `selector`,
+            start: 0,
+            end: 6,
+            nodes: [
+              createNode({
+                type: `class`,
+                value: `z`,
+                start: 0,
+                end: 2,
+              }),
+              createNode({
+                type: `nesting`,
+                value: `&`,
+                start: 2,
+                end: 3,
+              }),
+              createNode({
+                type: `element`,
+                value: `div`,
+                start: 3,
+                end: 6,
               }),
             ],
           }),

--- a/packages/css-selector-parser/test/selector-parser.spec.ts
+++ b/packages/css-selector-parser/test/selector-parser.spec.ts
@@ -464,6 +464,25 @@ describe(`selector-parser`, () => {
         ],
       });
     });
+    it(`[&="&"]`, () => {
+      test(`[&="&"]`, {
+        expectedAst: [
+          createNode({
+            type: `selector`,
+            start: 0,
+            end: 7,
+            nodes: [
+              createNode({
+                type: `attribute`,
+                value: `&="&"`,
+                start: 0,
+                end: 7,
+              }),
+            ],
+          }),
+        ],
+      });
+    });
     it(`&`, () => {
       test(`&`, {
         expectedAst: [

--- a/packages/css-selector-parser/test/selector-parser.spec.ts
+++ b/packages/css-selector-parser/test/selector-parser.spec.ts
@@ -464,6 +464,25 @@ describe(`selector-parser`, () => {
         ],
       });
     });
+    it(`&`, () => {
+      test(`&`, {
+        expectedAst: [
+          createNode({
+            type: `selector`,
+            start: 0,
+            end: 1,
+            nodes: [
+              createNode({
+                type: `nesting`,
+                value: `&`,
+                start: 0,
+                end: 1,
+              }),
+            ],
+          }),
+        ],
+      });
+    });
   });
   describe(`nth`, () => {
     it(`:nth-child()`, () => {

--- a/packages/css-selector-parser/test/selector-parser.spec.ts
+++ b/packages/css-selector-parser/test/selector-parser.spec.ts
@@ -1546,7 +1546,143 @@ describe(`selector-parser`, () => {
       });
     });
   });
-  describe(`nesting`, () => {
+  describe(`nesting (not-native)`, () => {
+    it(`div(:hover)`, () => {
+      test(`div(:hover)`, {
+        expectedAst: [
+          createNode({
+            type: `selector`,
+            start: 0,
+            end: 11,
+            nodes: [
+              createNode({
+                type: `element`,
+                value: `div`,
+                start: 0,
+                end: 11,
+                nodes: [
+                  createNode({
+                    type: `selector`,
+                    start: 4,
+                    end: 10,
+                    nodes: [
+                      createNode({
+                        type: `pseudo_class`,
+                        value: `hover`,
+                        start: 4,
+                        end: 10,
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+    });
+    it(`#id(:hover)`, () => {
+      test(`#id(:hover)`, {
+        expectedAst: [
+          createNode({
+            type: `selector`,
+            start: 0,
+            end: 11,
+            nodes: [
+              createNode({
+                type: `id`,
+                value: `id`,
+                start: 0,
+                end: 11,
+                nodes: [
+                  createNode({
+                    type: `selector`,
+                    start: 4,
+                    end: 10,
+                    nodes: [
+                      createNode({
+                        type: `pseudo_class`,
+                        value: `hover`,
+                        start: 4,
+                        end: 10,
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+    });
+    it(`.a(:hover)`, () => {
+      test(`.a(:hover)`, {
+        expectedAst: [
+          createNode({
+            type: `selector`,
+            start: 0,
+            end: 10,
+            nodes: [
+              createNode({
+                type: `class`,
+                value: `a`,
+                start: 0,
+                end: 10,
+                nodes: [
+                  createNode({
+                    type: `selector`,
+                    start: 3,
+                    end: 9,
+                    nodes: [
+                      createNode({
+                        type: `pseudo_class`,
+                        value: `hover`,
+                        start: 3,
+                        end: 9,
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+    });
+    it(`[attr="val"](:hover)`, () => {
+      test(`[attr="val"](:hover)`, {
+        expectedAst: [
+          createNode({
+            type: `selector`,
+            start: 0,
+            end: 20,
+            nodes: [
+              createNode({
+                type: `attribute`,
+                value: `attr="val"`,
+                start: 0,
+                end: 20,
+                nodes: [
+                  createNode({
+                    type: `selector`,
+                    start: 13,
+                    end: 19,
+                    nodes: [
+                      createNode({
+                        type: `pseudo_class`,
+                        value: `hover`,
+                        start: 13,
+                        end: 19,
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+    });
     it(`&(:hover)`, () => {
       test(`&(:hover)`, {
         expectedAst: [


### PR DESCRIPTION
This PR add the [nesting selector](https://drafts.csswg.org/css-nesting/).

- new `nesting` ast type: `{ type: "nesting", value: "&", nodes: [] }`
- support non native inner nodes: `&(a, b)`