### PR TITLE
publish upgrade versions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tokey/core",
   "description": "simple code like tokenizer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/css-selector-parser/package.json
+++ b/packages/css-selector-parser/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@tokey/css-selector-parser",
   "description": "selector parser for css",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "mocha \"./dist/test/**/*.spec.js\""
   },
   "dependencies": {
-    "@tokey/core": "^1.0.0"
+    "@tokey/core": "^1.1.0"
   },
   "keywords": [
     "parser",


### PR DESCRIPTION
This PR upgrades the versions

- `core` -  1.0.0 -> 1.1.0
    - core adds support for escaping 
- `css-selector-parser` -  0.1.0 -> 0.2.0
    - escaping
    - nested selector
    - walk utility