### PR TITLE
feat(selector-parser): make stringifySelectorAst accept readonly

### DIFF
--- a/packages/css-selector-parser/src/ast-types.ts
+++ b/packages/css-selector-parser/src/ast-types.ts
@@ -7,10 +7,11 @@ export interface Selector extends Omit<Token<"selector">, "value"> {
   after: string;
 }
 
-export type NthWithSelectorList = [Nth, ...SelectorList];
+export type NthSelectorList = [Nth, ...SelectorList];
 
+// ToDo: try type NthSelectorList only for the specific set of types
 export interface PseudoClass extends Token<"pseudo_class"> {
-  nodes?: SelectorList | NthWithSelectorList;
+  nodes?: SelectorList | NthSelectorList;
   colonComments: Comment[];
 }
 
@@ -88,10 +89,10 @@ export interface Nth extends Omit<Token<"nth">, "value"> {
   // invalid?: boolean;
 }
 
-export type NamespacedNodes = Element | Star;
+export type NamespacedNode = Element | Star;
 
 export type Containers =
-  | NamespacedNodes
+  | NamespacedNode
   | Attribute
   | Id
   | Class
@@ -114,9 +115,14 @@ export type SelectorNodes = SelectorNode[];
 export type SelectorList = Selector[];
 
 // immutable ast
+export type ImmutableSelector = Immutable<Selector>;
+
 export type ImmutableSelectorList = Immutable<SelectorList>;
+export type ImmutableNthSelectorList = Immutable<NthSelectorList>;
+
 export type ImmutableSelectorNode = Immutable<SelectorNode>;
-export type ImmutableNthWithSelectorList = Immutable<NthWithSelectorList>;
+export type ImmutableContainers = Immutable<Containers>;
+export type ImmutableNamespacedNode = Immutable<NamespacedNode>;
 
 export type ImmutableStar = Immutable<Star>;
 export type ImmutableClass = Immutable<Class>;
@@ -128,7 +134,6 @@ export type ImmutablePseudoClass = Immutable<PseudoClass>;
 export type ImmutablePseudoElement = Immutable<PseudoElement>;
 export type ImmutableComment = Immutable<Comment>;
 export type ImmutableNesting = Immutable<Nesting>;
-export type ImmutableSelector = Immutable<Selector>;
 export type ImmutableInvalid = Immutable<Invalid>;
 export type ImmutableNth = Immutable<Nth>;
 export type ImmutableNthStep = Immutable<NthStep>;

--- a/packages/css-selector-parser/src/ast-types.ts
+++ b/packages/css-selector-parser/src/ast-types.ts
@@ -6,8 +6,10 @@ export interface Selector extends Omit<Token<"selector">, "value"> {
   after: string;
 }
 
+export type NthWithSelectorList = [Nth, ...SelectorList];
+
 export interface PseudoClass extends Token<"pseudo_class"> {
-  nodes?: Selector[] | [Nth, ...SelectorList];
+  nodes?: SelectorList | NthWithSelectorList;
   colonComments: Comment[];
 }
 
@@ -109,3 +111,17 @@ export type SelectorNode =
   | NthOf;
 export type SelectorNodes = SelectorNode[];
 export type SelectorList = Selector[];
+
+export type DeepReadonlySelectorList = DeepReadonly<SelectorList>;
+export type DeepReadonlySelectorNode = DeepReadonly<SelectorNode>;
+export type DeepReadonlyNthWithSelectorList = DeepReadonly<NthWithSelectorList>;
+
+export type DeepReadonly<T> = T extends (infer R)[]
+  ? ReadonlyArray<DeepReadonly<R>>
+  : T extends Function
+  ? T
+  : T extends object
+  ? {
+      readonly [P in keyof T]: DeepReadonly<T[P]>;
+    }
+  : T;

--- a/packages/css-selector-parser/src/ast-types.ts
+++ b/packages/css-selector-parser/src/ast-types.ts
@@ -1,3 +1,4 @@
+import type { Immutable } from "./types";
 import type { Token } from "@tokey/core";
 
 export interface Selector extends Omit<Token<"selector">, "value"> {
@@ -112,16 +113,25 @@ export type SelectorNode =
 export type SelectorNodes = SelectorNode[];
 export type SelectorList = Selector[];
 
-export type DeepReadonlySelectorList = DeepReadonly<SelectorList>;
-export type DeepReadonlySelectorNode = DeepReadonly<SelectorNode>;
-export type DeepReadonlyNthWithSelectorList = DeepReadonly<NthWithSelectorList>;
+// immutable ast
+export type ImmutableSelectorList = Immutable<SelectorList>;
+export type ImmutableSelectorNode = Immutable<SelectorNode>;
+export type ImmutableNthWithSelectorList = Immutable<NthWithSelectorList>;
 
-export type DeepReadonly<T> = T extends (infer R)[]
-  ? ReadonlyArray<DeepReadonly<R>>
-  : T extends Function
-  ? T
-  : T extends object
-  ? {
-      readonly [P in keyof T]: DeepReadonly<T[P]>;
-    }
-  : T;
+export type ImmutableStar = Immutable<Star>;
+export type ImmutableClass = Immutable<Class>;
+export type ImmutableId = Immutable<Id>;
+export type ImmutableElement = Immutable<Element>;
+export type ImmutableCombinator = Immutable<Combinator>;
+export type ImmutableAttribute = Immutable<Attribute>;
+export type ImmutablePseudoClass = Immutable<PseudoClass>;
+export type ImmutablePseudoElement = Immutable<PseudoElement>;
+export type ImmutableComment = Immutable<Comment>;
+export type ImmutableNesting = Immutable<Nesting>;
+export type ImmutableSelector = Immutable<Selector>;
+export type ImmutableInvalid = Immutable<Invalid>;
+export type ImmutableNth = Immutable<Nth>;
+export type ImmutableNthStep = Immutable<NthStep>;
+export type ImmutableNthDash = Immutable<NthDash>;
+export type ImmutableNthOffset = Immutable<NthOffset>;
+export type ImmutableNthOf = Immutable<NthOf>;

--- a/packages/css-selector-parser/src/helpers.ts
+++ b/packages/css-selector-parser/src/helpers.ts
@@ -4,7 +4,7 @@ import type {
   Comment,
   Selector,
   Nth,
-  NamespacedNodes,
+  NamespacedNode,
   SelectorList,
   SelectorNode,
 } from "./ast-types";
@@ -85,7 +85,7 @@ export function isNamespacedToken(
 ): token is Token<"text" | "*"> {
   return token.type === `*` || token.type === `text`;
 }
-export function isNamespacedAst(token: SelectorNode): token is NamespacedNodes {
+export function isNamespacedAst(token: SelectorNode): token is NamespacedNode {
   return token.type === `star` || token.type === `element`;
 }
 

--- a/packages/css-selector-parser/src/selector-parser.ts
+++ b/packages/css-selector-parser/src/selector-parser.ts
@@ -4,7 +4,7 @@ import type {
   Namespace,
   Combinator,
   Comment,
-  NamespacedNodes,
+  NamespacedNode,
   Selector,
   SelectorList,
   SelectorNode,
@@ -222,7 +222,7 @@ function handleToken(
     });
   } else if (token.type === "|") {
     // search backwards compatible namespace in ast
-    let prevAst: NamespacedNodes | undefined;
+    let prevAst: NamespacedNode | undefined;
     let prevInvalidAst: SelectorNode | undefined;
     const beforeComments: Comment[] = [];
     for (let i = ast.length - 1; i >= 0; --i) {
@@ -283,14 +283,14 @@ function handleToken(
       invalid = invalid ? `namespace,target` : `target`;
     }
     // create new ast or modify the prev
-    const nsAst: NamespacedNodes =
+    const nsAst: NamespacedNode =
       prevAst ||
       ({
         type,
         value: ``,
         start: token.start,
         end: target?.end || token.end,
-      } as NamespacedNodes);
+      } as NamespacedNode);
     nsAst.type = type;
     nsAst.namespace = {
       value: prevAst?.value || ``,

--- a/packages/css-selector-parser/src/stringify.ts
+++ b/packages/css-selector-parser/src/stringify.ts
@@ -17,63 +17,78 @@ import type {
   PseudoClass,
   PseudoElement,
   Selector,
-  SelectorList,
   SelectorNode,
   Star,
   Nesting,
+  DeepReadonlySelectorNode,
+  DeepReadonlySelectorList,
+  DeepReadonlyNthWithSelectorList,
+  DeepReadonly,
 } from "./ast-types";
 
 export function stringifySelectorAst(
-  value: SelectorNode | SelectorList | [Nth, ...SelectorList]
+  value:
+    | DeepReadonlySelectorNode
+    | DeepReadonlySelectorList
+    | DeepReadonlyNthWithSelectorList
 ): string {
-  return Array.isArray(value)
-    ? stringifySelectors(value)
-    : stringifyNode(value);
+  return "length" in value ? stringifySelectors(value) : stringifyNode(value);
 }
 
-type R = { [K in SelectorNode as K["type"]]: (node: K) => string };
+type Printers = {
+  [K in SelectorNode as K["type"]]: (node: DeepReadonly<K>) => string;
+};
 
-const printers: R = {
-  id: (node: Id) => `#${node.value}${stringifyNested(node)}`,
-  class: (node: Class) =>
+const printers: Printers = {
+  id: (node: DeepReadonly<Id>) => `#${node.value}${stringifyNested(node)}`,
+  class: (node: DeepReadonly<Class>) =>
     `.${node.dotComments.map(stringifyNode).join("")}${
       node.value
     }${stringifyNested(node)}`,
-  element: (node: Element) =>
+  element: (node: DeepReadonly<Element>) =>
     `${stringifyNamespace(node)}${node.value}${stringifyNested(node)}`,
-  combinator: (node: Combinator) => `${node.before}${node.value}${node.after}`,
-  attribute: (node: Attribute) => `[${node.value}]${stringifyNested(node)}`,
-  pseudo_class: (node: PseudoClass) =>
+  combinator: (node: DeepReadonly<Combinator>) =>
+    `${node.before}${node.value}${node.after}`,
+  attribute: (node: DeepReadonly<Attribute>) =>
+    `[${node.value}]${stringifyNested(node)}`,
+  pseudo_class: (node: DeepReadonly<PseudoClass>) =>
     `:${node.colonComments.map(stringifyNode).join("")}${
       node.value
     }${stringifyNested(node)}`,
-  pseudo_element: (node: PseudoElement) =>
+  pseudo_element: (node: DeepReadonly<PseudoElement>) =>
     `:${node.colonComments.first
       .map(stringifyNode)
       .join("")}:${node.colonComments.second.map(stringifyNode).join("")}${
       node.value
     }${stringifyNested(node)}`,
-  comment: ({ before, value, after }: Comment) => `${before}${value}${after}`,
-  star: (node: Star) =>
-    `${stringifyNamespace(node)}${node.value}${stringifyNested(node)}`,
-  nesting: (node: Nesting) => `${node.value}${stringifyNested(node)}`,
-  selector: (node: Selector) =>
-    `${node.before}${node.nodes.map(stringifyNode).join("")}${node.after}`,
-  invalid: (node: Invalid) => node.value,
-  nth: (node: Nth) =>
-    `${node.before}${node.nodes.map(stringifyNode).join("")}${node.after}`,
-  nth_step: ({ before, value, after }: NthStep) => `${before}${value}${after}`,
-  nth_dash: ({ before, value, after }: NthDash) => `${before}${value}${after}`,
-  nth_offset: ({ before, value, after }: NthOffset) =>
+  comment: ({ before, value, after }: DeepReadonly<Comment>) =>
     `${before}${value}${after}`,
-  nth_of: ({ before, value, after }: NthOf) => `${before}${value}${after}`,
+  star: (node: DeepReadonly<Star>) =>
+    `${stringifyNamespace(node)}${node.value}${stringifyNested(node)}`,
+  nesting: (node: DeepReadonly<Nesting>) =>
+    `${node.value}${stringifyNested(node)}`,
+  selector: (node: DeepReadonly<Selector>) =>
+    `${node.before}${node.nodes.map(stringifyNode).join("")}${node.after}`,
+  invalid: (node: DeepReadonly<Invalid>) => node.value,
+  nth: (node: DeepReadonly<Nth>) =>
+    `${node.before}${node.nodes.map(stringifyNode).join("")}${node.after}`,
+  nth_step: ({ before, value, after }: DeepReadonly<NthStep>) =>
+    `${before}${value}${after}`,
+  nth_dash: ({ before, value, after }: DeepReadonly<NthDash>) =>
+    `${before}${value}${after}`,
+  nth_offset: ({ before, value, after }: DeepReadonly<NthOffset>) =>
+    `${before}${value}${after}`,
+  nth_of: ({ before, value, after }: DeepReadonly<NthOf>) =>
+    `${before}${value}${after}`,
 };
 
-function stringifyNode(node: SelectorNode): string {
+function stringifyNode(node: DeepReadonlySelectorNode): string {
   return printers[node.type]?.(node as never) ?? "";
 }
 
-function stringifySelectors(selectors: SelectorList | [Nth, ...SelectorList]) {
+function stringifySelectors(
+  selectors: DeepReadonlySelectorList | DeepReadonlyNthWithSelectorList
+) {
   const result: string[] = [];
   for (const node of selectors) {
     result.push(stringifyNode(node));
@@ -81,20 +96,28 @@ function stringifySelectors(selectors: SelectorList | [Nth, ...SelectorList]) {
   return result.join(`,`);
 }
 
-function stringifyNested(node: Containers): string {
+function stringifyNested(node: DeepReadonly<Containers>): string {
   if ("nodes" in node) {
     if (node.nodes?.length) {
-      const isNth =
-        node.type === `pseudo_class` && NthParser.isNthPseudoClass(node.value);
-      const nthExpr = isNth ? stringifyNode(node.nodes.shift()!) : ``;
-      return `(${nthExpr}${stringifySelectors(node.nodes)})`;
+      if (
+        node.type === `pseudo_class` &&
+        NthParser.isNthPseudoClass(node.value)
+      ) {
+        const [nthNode, ...selectors] = node.nodes;
+        return `(${stringifyNode(nthNode)}${stringifySelectors(selectors)})`;
+      } else {
+        return `(${stringifySelectors(node.nodes)})`;
+      }
     } else {
       return `()`;
     }
   }
   return "";
 }
-function stringifyNamespace({ namespace }: NamespacedNodes): string {
+
+function stringifyNamespace({
+  namespace,
+}: DeepReadonly<NamespacedNodes>): string {
   let ns = ``;
   if (namespace) {
     ns += namespace.value;

--- a/packages/css-selector-parser/src/stringify.ts
+++ b/packages/css-selector-parser/src/stringify.ts
@@ -1,84 +1,82 @@
 import { NthParser } from "./nth-parser";
 import type {
-  Id,
-  Attribute,
-  Class,
-  Combinator,
-  Comment,
-  Containers,
-  Element,
-  Invalid,
-  NamespacedNodes,
-  Nth,
-  NthDash,
-  NthOf,
-  NthOffset,
-  NthStep,
-  PseudoClass,
-  PseudoElement,
-  Selector,
-  SelectorNode,
-  Star,
-  Nesting,
+  ImmutableId,
+  ImmutableAttribute,
+  ImmutableClass,
+  ImmutableCombinator,
+  ImmutableComment,
+  ImmutableElement,
+  ImmutableInvalid,
+  ImmutableNth,
+  ImmutableNthDash,
+  ImmutableNthOf,
+  ImmutableNthOffset,
+  ImmutableNthStep,
+  ImmutablePseudoClass,
+  ImmutablePseudoElement,
+  ImmutableSelector,
+  ImmutableStar,
+  ImmutableNesting,
   ImmutableSelectorNode,
   ImmutableSelectorList,
-  ImmutableNthWithSelectorList,
+  ImmutableNthSelectorList,
+  ImmutableContainers,
+  ImmutableNamespacedNode,
 } from "./ast-types";
-import type {Immutable} from "./types";
 
 export function stringifySelectorAst(
   value:
     | ImmutableSelectorNode
     | ImmutableSelectorList
-    | ImmutableNthWithSelectorList
+    | ImmutableNthSelectorList
 ): string {
   return "length" in value ? stringifySelectors(value) : stringifyNode(value);
 }
 
 type Printers = {
-  [K in SelectorNode as K["type"]]: (node: Immutable<K>) => string;
+  [K in ImmutableSelectorNode as K["type"]]: (node: K) => string;
 };
 
 const printers: Printers = {
-  id: (node: Immutable<Id>) => `#${node.value}${stringifyNested(node)}`,
-  class: (node: Immutable<Class>) =>
+  id: (node: ImmutableId) => `#${node.value}${stringifyNested(node)}`,
+  class: (node: ImmutableClass) =>
     `.${node.dotComments.map(stringifyNode).join("")}${
       node.value
     }${stringifyNested(node)}`,
-  element: (node: Immutable<Element>) =>
+  element: (node: ImmutableElement) =>
     `${stringifyNamespace(node)}${node.value}${stringifyNested(node)}`,
-  combinator: (node: Immutable<Combinator>) =>
+  combinator: (node: ImmutableCombinator) =>
     `${node.before}${node.value}${node.after}`,
-  attribute: (node: Immutable<Attribute>) =>
+  attribute: (node: ImmutableAttribute) =>
     `[${node.value}]${stringifyNested(node)}`,
-  pseudo_class: (node: Immutable<PseudoClass>) =>
+  pseudo_class: (node: ImmutablePseudoClass) =>
     `:${node.colonComments.map(stringifyNode).join("")}${
       node.value
     }${stringifyNested(node)}`,
-  pseudo_element: (node: Immutable<PseudoElement>) =>
+  pseudo_element: (node: ImmutablePseudoElement) =>
     `:${node.colonComments.first
       .map(stringifyNode)
       .join("")}:${node.colonComments.second.map(stringifyNode).join("")}${
       node.value
     }${stringifyNested(node)}`,
-  comment: ({ before, value, after }: Immutable<Comment>) =>
+  comment: ({ before, value, after }: ImmutableComment) =>
     `${before}${value}${after}`,
-  star: (node: Immutable<Star>) =>
+  star: (node: ImmutableStar) =>
     `${stringifyNamespace(node)}${node.value}${stringifyNested(node)}`,
-  nesting: (node: Immutable<Nesting>) =>
+  nesting: (node: ImmutableNesting) =>
     `${node.value}${stringifyNested(node)}`,
-  selector: (node: Immutable<Selector>) =>
+  selector: (node: ImmutableSelector) =>
     `${node.before}${node.nodes.map(stringifyNode).join("")}${node.after}`,
-  invalid: (node: Immutable<Invalid>) => node.value,
-  nth: (node: Immutable<Nth>) =>
+  invalid: (node: ImmutableInvalid) => node.value,
+  nth: (node: ImmutableNth) =>
     `${node.before}${node.nodes.map(stringifyNode).join("")}${node.after}`,
-  nth_step: ({ before, value, after }: Immutable<NthStep>) =>
+  nth_step: ({ before, value, after }: ImmutableNthStep) =>
     `${before}${value}${after}`,
-  nth_dash: ({ before, value, after }: Immutable<NthDash>) =>
+  nth_dash: ({ before, value, after }: ImmutableNthDash) =>
     `${before}${value}${after}`,
-  nth_offset: ({ before, value, after }: Immutable<NthOffset>) =>
+  nth_offset: ({ before, value, after }: ImmutableNthOffset) =>
     `${before}${value}${after}`,
-  nth_of: ({ before, value, after }: Immutable<NthOf>) =>
+  nth_of: ({ before, value, after }: ImmutableNthOf) =>
     `${before}${value}${after}`,
 };
 
@@ -87,7 +85,7 @@ function stringifyNode(node: ImmutableSelectorNode): string {
 }
 
 function stringifySelectors(
-  selectors: ImmutableSelectorList | ImmutableNthWithSelectorList
+  selectors: ImmutableSelectorList | ImmutableNthSelectorList
 ) {
   const result: string[] = [];
   for (const node of selectors) {
@@ -96,7 +94,7 @@ function stringifySelectors(
   return result.join(`,`);
 }
 
-function stringifyNested(node: Immutable<Containers>): string {
+function stringifyNested(node: ImmutableContainers): string {
   if ("nodes" in node) {
     if (node.nodes?.length) {
       if (
@@ -117,7 +115,7 @@ function stringifyNested(node: Immutable<Containers>): string {
 
 function stringifyNamespace({
   namespace,
-}: Immutable<NamespacedNodes>): string {
+}: ImmutableNamespacedNode): string {
   let ns = ``;
   if (namespace) {
     ns += namespace.value;

--- a/packages/css-selector-parser/src/stringify.ts
+++ b/packages/css-selector-parser/src/stringify.ts
@@ -20,74 +20,74 @@ import type {
   SelectorNode,
   Star,
   Nesting,
-  DeepReadonlySelectorNode,
-  DeepReadonlySelectorList,
-  DeepReadonlyNthWithSelectorList,
-  DeepReadonly,
+  ImmutableSelectorNode,
+  ImmutableSelectorList,
+  ImmutableNthWithSelectorList,
 } from "./ast-types";
+import type {Immutable} from "./types";
 
 export function stringifySelectorAst(
   value:
-    | DeepReadonlySelectorNode
-    | DeepReadonlySelectorList
-    | DeepReadonlyNthWithSelectorList
+    | ImmutableSelectorNode
+    | ImmutableSelectorList
+    | ImmutableNthWithSelectorList
 ): string {
   return "length" in value ? stringifySelectors(value) : stringifyNode(value);
 }
 
 type Printers = {
-  [K in SelectorNode as K["type"]]: (node: DeepReadonly<K>) => string;
+  [K in SelectorNode as K["type"]]: (node: Immutable<K>) => string;
 };
 
 const printers: Printers = {
-  id: (node: DeepReadonly<Id>) => `#${node.value}${stringifyNested(node)}`,
-  class: (node: DeepReadonly<Class>) =>
+  id: (node: Immutable<Id>) => `#${node.value}${stringifyNested(node)}`,
+  class: (node: Immutable<Class>) =>
     `.${node.dotComments.map(stringifyNode).join("")}${
       node.value
     }${stringifyNested(node)}`,
-  element: (node: DeepReadonly<Element>) =>
+  element: (node: Immutable<Element>) =>
     `${stringifyNamespace(node)}${node.value}${stringifyNested(node)}`,
-  combinator: (node: DeepReadonly<Combinator>) =>
+  combinator: (node: Immutable<Combinator>) =>
     `${node.before}${node.value}${node.after}`,
-  attribute: (node: DeepReadonly<Attribute>) =>
+  attribute: (node: Immutable<Attribute>) =>
     `[${node.value}]${stringifyNested(node)}`,
-  pseudo_class: (node: DeepReadonly<PseudoClass>) =>
+  pseudo_class: (node: Immutable<PseudoClass>) =>
     `:${node.colonComments.map(stringifyNode).join("")}${
       node.value
     }${stringifyNested(node)}`,
-  pseudo_element: (node: DeepReadonly<PseudoElement>) =>
+  pseudo_element: (node: Immutable<PseudoElement>) =>
     `:${node.colonComments.first
       .map(stringifyNode)
       .join("")}:${node.colonComments.second.map(stringifyNode).join("")}${
       node.value
     }${stringifyNested(node)}`,
-  comment: ({ before, value, after }: DeepReadonly<Comment>) =>
+  comment: ({ before, value, after }: Immutable<Comment>) =>
     `${before}${value}${after}`,
-  star: (node: DeepReadonly<Star>) =>
+  star: (node: Immutable<Star>) =>
     `${stringifyNamespace(node)}${node.value}${stringifyNested(node)}`,
-  nesting: (node: DeepReadonly<Nesting>) =>
+  nesting: (node: Immutable<Nesting>) =>
     `${node.value}${stringifyNested(node)}`,
-  selector: (node: DeepReadonly<Selector>) =>
+  selector: (node: Immutable<Selector>) =>
     `${node.before}${node.nodes.map(stringifyNode).join("")}${node.after}`,
-  invalid: (node: DeepReadonly<Invalid>) => node.value,
-  nth: (node: DeepReadonly<Nth>) =>
+  invalid: (node: Immutable<Invalid>) => node.value,
+  nth: (node: Immutable<Nth>) =>
     `${node.before}${node.nodes.map(stringifyNode).join("")}${node.after}`,
-  nth_step: ({ before, value, after }: DeepReadonly<NthStep>) =>
+  nth_step: ({ before, value, after }: Immutable<NthStep>) =>
     `${before}${value}${after}`,
-  nth_dash: ({ before, value, after }: DeepReadonly<NthDash>) =>
+  nth_dash: ({ before, value, after }: Immutable<NthDash>) =>
     `${before}${value}${after}`,
-  nth_offset: ({ before, value, after }: DeepReadonly<NthOffset>) =>
+  nth_offset: ({ before, value, after }: Immutable<NthOffset>) =>
     `${before}${value}${after}`,
-  nth_of: ({ before, value, after }: DeepReadonly<NthOf>) =>
+  nth_of: ({ before, value, after }: Immutable<NthOf>) =>
     `${before}${value}${after}`,
 };
 
-function stringifyNode(node: DeepReadonlySelectorNode): string {
+function stringifyNode(node: ImmutableSelectorNode): string {
   return printers[node.type]?.(node as never) ?? "";
 }
 
 function stringifySelectors(
-  selectors: DeepReadonlySelectorList | DeepReadonlyNthWithSelectorList
+  selectors: ImmutableSelectorList | ImmutableNthWithSelectorList
 ) {
   const result: string[] = [];
   for (const node of selectors) {
@@ -96,7 +96,7 @@ function stringifySelectors(
   return result.join(`,`);
 }
 
-function stringifyNested(node: DeepReadonly<Containers>): string {
+function stringifyNested(node: Immutable<Containers>): string {
   if ("nodes" in node) {
     if (node.nodes?.length) {
       if (
@@ -117,7 +117,7 @@ function stringifyNested(node: DeepReadonly<Containers>): string {
 
 function stringifyNamespace({
   namespace,
-}: DeepReadonly<NamespacedNodes>): string {
+}: Immutable<NamespacedNodes>): string {
   let ns = ``;
   if (namespace) {
     ns += namespace.value;

--- a/packages/css-selector-parser/src/types.ts
+++ b/packages/css-selector-parser/src/types.ts
@@ -1,0 +1,13 @@
+// ToDo: move to types.ts
+/**
+ * convert object|array into a replica deep readonly type
+ */
+export type Immutable<T> = T extends (infer R)[]
+  ? ReadonlyArray<Immutable<R>>
+  : T extends Function
+  ? T
+  : T extends object
+  ? {
+      readonly [P in keyof T]: Immutable<T[P]>;
+    }
+  : T;

--- a/packages/css-selector-parser/test/stringify.spec.ts
+++ b/packages/css-selector-parser/test/stringify.spec.ts
@@ -2,7 +2,7 @@ import { stringifySelectorAst, parseCssSelector } from '@tokey/css-selector-pars
 import type {
     ImmutableSelectorList,
     ImmutableSelector,
-    ImmutableNthWithSelectorList,
+    ImmutableNthSelectorList,
     ImmutableStar,
     ImmutableClass,
     ImmutableId,
@@ -52,7 +52,7 @@ describe(`stringifySelectorAst`, () => {
             { src: `:nth-child(5n of)` } as any as ImmutableNthOf,
             { src: `.a, .b` } as any as ImmutableSelectorList,
             { src: `.a.b` } as any as ImmutableSelector,
-            { src: `:nth-child(5n of div)` } as any as ImmutableNthWithSelectorList,
+            { src: `:nth-child(5n of div)` } as any as ImmutableNthSelectorList,
         ].forEach((ast) => {
             stringifySelectorAst(ast); // expect no type error
         });

--- a/packages/css-selector-parser/test/stringify.spec.ts
+++ b/packages/css-selector-parser/test/stringify.spec.ts
@@ -1,0 +1,61 @@
+import { stringifySelectorAst, parseCssSelector } from '@tokey/css-selector-parser';
+import type {
+    ImmutableSelectorList,
+    ImmutableSelector,
+    ImmutableNthWithSelectorList,
+    ImmutableStar,
+    ImmutableClass,
+    ImmutableId,
+    ImmutableElement,
+    ImmutableCombinator,
+    ImmutableAttribute,
+    ImmutablePseudoClass,
+    ImmutablePseudoElement,
+    ImmutableComment,
+    ImmutableNesting,
+    ImmutableInvalid,
+    ImmutableNth,
+    ImmutableNthStep,
+    ImmutableNthDash,
+    ImmutableNthOffset,
+    ImmutableNthOf,
+} from '@tokey/css-selector-parser';
+import { expect } from 'chai';
+
+describe(`stringifySelectorAst`, () => {
+    it(`should convert ast back to string`, () => {
+        const ast = parseCssSelector(`.a`);
+
+        const selector = stringifySelectorAst(ast);
+
+        expect(selector).to.equal(`.a`);
+    });
+    describe(`immutable`, () => {
+        // test types
+        [
+            { src: `*` } as any as ImmutableStar,
+            { src: `.a` } as any as ImmutableClass,
+            { src: `#id` } as any as ImmutableId,
+            { src: `el` } as any as ImmutableElement,
+            { src: `+` } as any as ImmutableCombinator,
+            { src: `[attr]` } as any as ImmutableAttribute,
+            { src: `:p-class` } as any as ImmutablePseudoClass,
+            { src: `::p-el` } as any as ImmutablePseudoElement,
+            { src: `/*comment*/` } as any as ImmutableComment,
+            { src: `&` } as any as ImmutableNesting,
+            { src: `.a` } as any as ImmutableSelector,
+            { src: `{` } as any as ImmutableInvalid,
+            { src: `:nth-child(5n)` } as any as ImmutableNth,
+            { src: `:nth-child(5n)` } as any as ImmutableNthStep,
+            { src: `:nth-child(5n-)` } as any as ImmutableNthDash,
+            { src: `:nth-child(5n-4)` } as any as ImmutableNthOffset,
+            { src: `:nth-child(5n of)` } as any as ImmutableNthOf,
+            { src: `.a, .b` } as any as ImmutableSelectorList,
+            { src: `.a.b` } as any as ImmutableSelector,
+            { src: `:nth-child(5n of div)` } as any as ImmutableNthWithSelectorList,
+        ].forEach((ast) => {
+            stringifySelectorAst(ast); // expect no type error
+        });
+        
+    });
+});


### PR DESCRIPTION
Readonly everywhere.
This also fix a bug that the printer of pseudo-class nth was mutating the node. 

fixes: #26