### PR TITLE
feat: start position from an initial offset

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,6 +27,7 @@ interface Options<T extends Token<unknown>> {
   isDelimiter(char: string): boolean;
   isWhitespace(char: string): boolean;
   createToken(value: string, type: T["type"], start: number, end: number): T;
+  offset?: number;
 }
 
 function tokenize<T extends Token<unknown>>(

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -19,6 +19,7 @@ export interface TokyOptions<T extends Token<unknown>> {
   ): boolean;
   getUnclosedComment(inComment: string): string;
   createToken(value: string, type: T["type"], start: number, end: number): T;
+  offset?: number;
 }
 
 export function tokenize<T extends Token<unknown>>(
@@ -32,6 +33,7 @@ export function tokenize<T extends Token<unknown>>(
     getCommentStartType,
     isCommentEnd,
     getUnclosedComment,
+    offset = 0,
   }: TokyOptions<T>
 ): T[] {
   const tokens: T[] = [];
@@ -39,8 +41,8 @@ export function tokenize<T extends Token<unknown>>(
   let buffer = "";
   let inComment = "";
   let inString = "";
-  let start = 0;
-  let nextCharIndex = 0;
+  let start = offset;
+  let nextCharIndex = offset;
   for (const ch of source) {
     nextCharIndex += ch.length;
     if (inString) {
@@ -51,11 +53,21 @@ export function tokenize<T extends Token<unknown>>(
       }
     } else if (inComment) {
       buffer += ch;
-      if (isCommentEnd(inComment, ch, source, nextCharIndex, previousChar)) {
+      if (
+        isCommentEnd(
+          inComment,
+          ch,
+          source,
+          nextCharIndex - offset,
+          previousChar
+        )
+      ) {
         pushBuffer(inComment);
         inComment = "";
       }
-    } else if ((inComment = getCommentStartType(ch, source, nextCharIndex))) {
+    } else if (
+      (inComment = getCommentStartType(ch, source, nextCharIndex - offset))
+    ) {
       pushBuffer();
       buffer += ch;
     } else if (isStringDelimiter(ch, previousChar)) {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -42,7 +42,7 @@ export function tokenize<T extends Token<unknown>>(
   let inComment = "";
   let inString = "";
   let start = offset;
-  let nextCharIndex = offset;
+  let nextCharIndex = 0;
   for (const ch of source) {
     nextCharIndex += ch.length;
     if (inString) {
@@ -58,7 +58,7 @@ export function tokenize<T extends Token<unknown>>(
           inComment,
           ch,
           source,
-          nextCharIndex - offset,
+          nextCharIndex,
           previousChar
         )
       ) {
@@ -66,7 +66,7 @@ export function tokenize<T extends Token<unknown>>(
         inComment = "";
       }
     } else if (
-      (inComment = getCommentStartType(ch, source, nextCharIndex - offset))
+      (inComment = getCommentStartType(ch, source, nextCharIndex))
     ) {
       pushBuffer();
       buffer += ch;

--- a/packages/core/test/core.spec.ts
+++ b/packages/core/test/core.spec.ts
@@ -191,4 +191,16 @@ describe("core - tokenize", () => {
       ]);
     });
   });
+  describe(`offset`, () => {
+    it(`should start from a given offset`, () => {
+      test(
+        `1/*"23"*/`,
+        (source: string) => tokenize(source, { ...options, offset: 10 }),
+        [
+          { value: "1", type: "text", start: 10, end: 11 },
+          { value: '/*"23"*/', type: "multi-comment", start: 11, end: 19 },
+        ]
+      );
+    });
+  });
 });

--- a/packages/css-selector-parser/README.md
+++ b/packages/css-selector-parser/README.md
@@ -81,6 +81,14 @@ const selectorList = parseCssSelector(`.card, .box`);
 */
 ```
 
+#### parsing config
+
+`offset` - start AST offset from a given point, defaults to 0:
+
+```js
+parseCssSelector(`ul`, { offset: 105 });
+```
+
 ### Stringify
 
 `stringifySelectorAst` - converts an AST node back into its string representation.

--- a/packages/css-selector-parser/src/index.ts
+++ b/packages/css-selector-parser/src/index.ts
@@ -1,4 +1,5 @@
 export { parseCssSelector } from "./selector-parser";
+export type { ParseConfig } from "./selector-parser";
 export * from "./ast-types";
 export { stringifySelectorAst } from "./stringify";
 export { walk } from "./ast-utils";

--- a/packages/css-selector-parser/src/selector-parser.ts
+++ b/packages/css-selector-parser/src/selector-parser.ts
@@ -22,8 +22,12 @@ import {
 } from "./helpers";
 import { isComment, getText, Seeker, last } from "@tokey/core";
 
-export function parseCssSelector(source: string) {
-  return parseTokens(source, tokenizeSelector(source));
+export interface ParseConfig {
+  offset: number;
+}
+
+export function parseCssSelector(source: string, options: Partial<ParseConfig> = {}) {
+  return parseTokens(source, tokenizeSelector(source, options));
 }
 
 function parseTokens(source: string, tokens: CSSSelectorToken[]): SelectorList {

--- a/packages/css-selector-parser/src/tokenizer.ts
+++ b/packages/css-selector-parser/src/tokenizer.ts
@@ -30,7 +30,10 @@ type Delimiters =
 
 export type CSSSelectorToken = Token<Descriptors | Delimiters>;
 
-export function tokenizeSelector(source: string) {
+export function tokenizeSelector(
+  source: string,
+  options: { offset?: number } = {}
+) {
   const parseLineComments = false; // why would that be a choice?
   return tokenize<CSSSelectorToken>(source, {
     isDelimiter,
@@ -45,6 +48,7 @@ export function tokenizeSelector(source: string) {
       : getMultilineCommentStartType,
     isCommentEnd,
     getUnclosedComment,
+    offset: options.offset,
   });
 }
 

--- a/packages/css-selector-parser/test/selector-parser.spec.ts
+++ b/packages/css-selector-parser/test/selector-parser.spec.ts
@@ -3480,4 +3480,28 @@ describe(`selector-parser`, () => {
       });
     });
   });
+  describe(`config`, () => {
+    describe(`offset`, () => {
+      it(`should start from a given offset`, () => {
+        test(`.classX`, {
+          config: { offset: 10 },
+          expectedAst: [
+            createNode({
+              type: `selector`,
+              start: 10,
+              end: 17,
+              nodes: [
+                createNode({
+                  type: `class`,
+                  value: `classX`,
+                  start: 10,
+                  end: 17,
+                }),
+              ],
+            }),
+          ],
+        });
+      });
+    });
+  });
 });

--- a/packages/css-selector-parser/test/test-kit/parsing.ts
+++ b/packages/css-selector-parser/test/test-kit/parsing.ts
@@ -11,11 +11,12 @@ import type {
   NthDash,
   NthOffset,
   NthOf,
+  ParseConfig,
 } from "@tokey/css-selector-parser";
 import { createParseTester } from "@tokey/test-kit";
 
 export const test = createParseTester({
-  parse: parseCssSelector,
+  parse: (selector: string, config?: ParseConfig) => parseCssSelector(selector, config),
   stringify: stringifySelectorAst,
 });
 

--- a/packages/test-kit/src/parse-tester.ts
+++ b/packages/test-kit/src/parse-tester.ts
@@ -1,33 +1,42 @@
 import { isMatch } from "./is-match";
 
-export interface TesterConfig<AST, INPUT extends string> {
-  parse: (input: INPUT) => AST;
+export interface TesterConfig<
+  AST,
+  INPUT extends string,
+  CONFIG
+> {
+  parse: (input: INPUT, options?: CONFIG) => AST;
   stringify?: (ast: AST) => string;
   log?: (...msgs: string[]) => void;
 }
 
-export interface TestOptions<AST> {
+export interface TestOptions<AST, CONFIG> {
   expectedAst: AST;
   expectedString?: string;
   label?: string;
+  config?: CONFIG;
 }
 
-export function createParseTester<AST, INPUT extends string>({
+export function createParseTester<
+  AST,
+  INPUT extends string,
+  CONFIG
+>({
   parse,
   stringify,
-}: TesterConfig<AST, INPUT>) {
-  const safeParse = (source: INPUT) => {
+}: TesterConfig<AST, INPUT, CONFIG>) {
+  const safeParse = (source: INPUT, config?: CONFIG) => {
     try {
-      return [parse(source), null];
+      return [parse(source, config), null];
     } catch (error) {
       return [null, error];
     }
   };
   return (
     source: INPUT,
-    { expectedAst, expectedString, label }: TestOptions<AST>
+    { expectedAst, expectedString, label, config }: TestOptions<AST, CONFIG>
   ) => {
-    const [actualAst, parseError] = safeParse(source);
+    const [actualAst, parseError] = safeParse(source, config);
     if (parseError) {
       throw parseError;
     }


### PR DESCRIPTION
This PR adds an offset configuration to both the `css-selector-parser` and the `core tokenizer` to start from.

resolves #24 

Also adding config option to the test-kit `createParseTester`.