### PR TITLE
css selector calculate specificity tool

### DIFF
--- a/packages/css-selector-parser/README.md
+++ b/packages/css-selector-parser/README.md
@@ -285,6 +285,37 @@ const compoundSelectorList = groupCompoundSelectors(selectorList, {splitPseudoEl
 ]
 ```
 
+### Selector specificity
+
+`calcSpecificity` take a `Selector` and returns it's specificity value
+
+```js
+import {
+    parseCssSelector,
+    calcSpecificity,
+} from '@tokey/css-selector-parser';
+
+const specificity = parseCssSelector(`span.x.y#z`);
+// [0, 1, 2, 1]
+```
+
+`compareSpecificity` takes 2 specificity values and return 0 if they are equal, 1 if the first is higher and -1 if the second is higher:
+
+```js
+import {
+    compareSpecificity,
+} from '@tokey/css-selector-parser';
+
+compareSpecificity(
+    [0, 2, 0, 0],
+    [0, 1, 0, 0]
+) // 1
+compareSpecificity(
+    [0, 0, 2, 0],
+    [0, 1, 0, 0]
+) // -1
+```
+
 ## Design decisions
 
 ### Escaping

--- a/packages/css-selector-parser/src/ast-tools/specificity.ts
+++ b/packages/css-selector-parser/src/ast-tools/specificity.ts
@@ -1,18 +1,15 @@
 import type {
   ImmutableSelectorNode,
-  ImmutableSelectorList,
   ImmutablePseudoClass,
-  SelectorList,
+  SelectorNode,
 } from "../ast-types";
 import { walk } from "./walk";
 
 type Specificity = [number, number, number, number];
-export function calcSpecificity(
-  ast: ImmutableSelectorList | ImmutableSelectorNode
-): Specificity {
+export function calcSpecificity(ast: ImmutableSelectorNode): Specificity {
   const result: Specificity = [0, 0, 0, 0];
   // ToDo: remove casting once immutable walk is supported
-  walk(ast as SelectorList, (node) => {
+  walk(ast as SelectorNode, (node) => {
     switch (node.type) {
       case `type`:
       case `pseudo_element`:

--- a/packages/css-selector-parser/src/ast-tools/specificity.ts
+++ b/packages/css-selector-parser/src/ast-tools/specificity.ts
@@ -1,0 +1,106 @@
+import type {
+  ImmutableSelectorNode,
+  ImmutableSelectorList,
+  ImmutablePseudoClass,
+  SelectorList,
+} from "../ast-types";
+import { walk } from "./walk";
+
+type Specificity = [number, number, number, number];
+export function calcSpecificity(
+  ast: ImmutableSelectorList | ImmutableSelectorNode
+): Specificity {
+  const result: Specificity = [0, 0, 0, 0];
+  // ToDo: remove casting once immutable walk is supported
+  walk(ast as SelectorList, (node) => {
+    switch (node.type) {
+      case `type`:
+      case `pseudo_element`:
+        result[3]++;
+        break;
+      case `class`:
+      case `attribute`:
+        result[2]++;
+        break;
+      case `pseudo_class`:
+        if (customPseudoClass[node.value]) {
+          customPseudoClass[node.value](node, result);
+          return walk.skipNested;
+        }
+        result[2]++;
+        break;
+      case `id`:
+        result[1]++;
+        break;
+    }
+    return;
+  });
+  return result;
+}
+
+const customPseudoClass: Record<
+  string,
+  (node: ImmutablePseudoClass, result: Specificity) => void
+> = {
+  not: mostSpecificInnerSelector,
+  is: mostSpecificInnerSelector,
+  has: mostSpecificInnerSelector,
+  where: () => {
+    /* no specificity*/
+  },
+  "nth-child": pseudoClassPlusMostSpecificInnerSelector,
+  "nth-last-child": pseudoClassPlusMostSpecificInnerSelector,
+  "nth-of-type": pseudoClassPlusMostSpecificInnerSelector,
+  "nth-last-of-type": pseudoClassPlusMostSpecificInnerSelector,
+};
+
+function pseudoClassPlusMostSpecificInnerSelector(
+  node: ImmutablePseudoClass,
+  result: Specificity
+) {
+  result[2]++;
+  mostSpecificInnerSelector(node, result);
+}
+function mostSpecificInnerSelector(
+  node: ImmutablePseudoClass,
+  result: Specificity
+) {
+  if (node.nodes) {
+    let highest: Specificity | undefined;
+    for (const selector of node.nodes) {
+      const currentSpecificity = calcSpecificity(selector);
+      if (!highest || compareSpecificity(currentSpecificity, highest) === 1) {
+        highest = currentSpecificity;
+      }
+    }
+    addSpecificity(result, highest!);
+  }
+}
+/**
+ * compare 2 specificities
+ * @param a first specificity
+ * @param b second specificity
+ * @returns 0 if equal, 1 when a is more specific, -1 when b is more specific
+ */
+function compareSpecificity(a: Specificity, b: Specificity): -1 | 0 | 1 {
+  for (let i = 0; i < 4; ++i) {
+    const specificityDiff = a[i] - b[i];
+    if (specificityDiff > 0) {
+      return 1;
+    } else if (specificityDiff < 0) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+/**
+ * mutate the first value, adding the second one
+ * @param to specificity reference to to
+ * @param from specificity amount to add
+ */
+function addSpecificity(to: Specificity, from: Specificity) {
+  for (let i = 0; i < 4; ++i) {
+    to[i] += from[i];
+  }
+}

--- a/packages/css-selector-parser/src/ast-tools/specificity.ts
+++ b/packages/css-selector-parser/src/ast-tools/specificity.ts
@@ -33,7 +33,9 @@ export function calcSpecificity(
         result[1]++;
         break;
     }
-    return node.type !== `selector` ? walk.skipNested : undefined;
+    return node.type !== `selector` && node.type !== `compound_selector`
+      ? walk.skipNested
+      : undefined;
   });
   return result;
 }

--- a/packages/css-selector-parser/src/ast-tools/specificity.ts
+++ b/packages/css-selector-parser/src/ast-tools/specificity.ts
@@ -69,15 +69,15 @@ function mostSpecificInnerSelector(
   node: ImmutablePseudoClass,
   result: Specificity
 ) {
-  if (node.nodes) {
-    let highest: Specificity | undefined;
+  if (node.nodes?.length) {
+    let highest: Specificity = [0, 0, 0, 0];
     for (const selector of node.nodes) {
       const currentSpecificity = calcSpecificity(selector);
       if (!highest || compareSpecificity(currentSpecificity, highest) === 1) {
         highest = currentSpecificity;
       }
     }
-    addSpecificity(result, highest!);
+    addSpecificity(result, highest);
   }
 }
 /**

--- a/packages/css-selector-parser/src/ast-tools/specificity.ts
+++ b/packages/css-selector-parser/src/ast-tools/specificity.ts
@@ -81,7 +81,7 @@ function mostSpecificInnerSelector(
  * @param b second specificity
  * @returns 0 if equal, 1 when a is more specific, -1 when b is more specific
  */
-function compareSpecificity(a: Specificity, b: Specificity): -1 | 0 | 1 {
+export function compareSpecificity(a: Specificity, b: Specificity): -1 | 0 | 1 {
   for (let i = 0; i < 4; ++i) {
     const specificityDiff = a[i] - b[i];
     if (specificityDiff > 0) {

--- a/packages/css-selector-parser/src/ast-tools/specificity.ts
+++ b/packages/css-selector-parser/src/ast-tools/specificity.ts
@@ -5,7 +5,12 @@ import type {
 } from "../ast-types";
 import { walk } from "./walk";
 
-type Specificity = [number, number, number, number];
+export type Specificity = [
+  inlineLevel: number,
+  idLevel: number,
+  classOrAttributeLevel: number,
+  typeOrElementLevel: number
+];
 export function calcSpecificity(ast: ImmutableSelectorNode): Specificity {
   const result: Specificity = [0, 0, 0, 0];
   // ToDo: remove casting once immutable walk is supported

--- a/packages/css-selector-parser/src/ast-tools/specificity.ts
+++ b/packages/css-selector-parser/src/ast-tools/specificity.ts
@@ -33,7 +33,7 @@ export function calcSpecificity(
         result[1]++;
         break;
     }
-    return;
+    return node.type !== `selector` ? walk.skipNested : undefined;
   });
   return result;
 }

--- a/packages/css-selector-parser/src/index.ts
+++ b/packages/css-selector-parser/src/index.ts
@@ -9,3 +9,4 @@ export {
   splitCompoundSelectors,
 } from "./ast-tools/compound";
 export { calcSpecificity, compareSpecificity } from "./ast-tools/specificity";
+export type { Specificity } from "./ast-tools/specificity";

--- a/packages/css-selector-parser/src/index.ts
+++ b/packages/css-selector-parser/src/index.ts
@@ -4,5 +4,8 @@ export * from "./ast-types";
 export { stringifySelectorAst } from "./stringify";
 export { walk } from "./ast-tools/walk";
 export type { WalkOptions } from "./ast-tools/walk";
-export { groupCompoundSelectors, splitCompoundSelectors } from "./ast-tools/compound";
-export { calcSpecificity } from "./ast-tools/specificity";
+export {
+  groupCompoundSelectors,
+  splitCompoundSelectors,
+} from "./ast-tools/compound";
+export { calcSpecificity, compareSpecificity } from "./ast-tools/specificity";

--- a/packages/css-selector-parser/src/index.ts
+++ b/packages/css-selector-parser/src/index.ts
@@ -5,3 +5,4 @@ export { stringifySelectorAst } from "./stringify";
 export { walk } from "./ast-tools/walk";
 export type { WalkOptions } from "./ast-tools/walk";
 export { groupCompoundSelectors, splitCompoundSelectors } from "./ast-tools/compound";
+export { calcSpecificity } from "./ast-tools/specificity";

--- a/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
+++ b/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
@@ -2,97 +2,101 @@ import {
   calcSpecificity,
   groupCompoundSelectors,
   parseCssSelector,
+  ImmutableSelectorNode,
 } from "@tokey/css-selector-parser";
 import { expect } from "chai";
 
 describe(`ast-tools/specificity`, () => {
+  const basicSelectors = [
+    {
+      selectorType: `universal`,
+      selector: `*`,
+      expected: [0, 0, 0, 0],
+    },
+    {
+      selectorType: `type`,
+      selector: `span`,
+      expected: [0, 0, 0, 1],
+    },
+    {
+      selectorType: `pseudo-element`,
+      selector: `::before`,
+      expected: [0, 0, 0, 1],
+    },
+    {
+      selectorType: `class`,
+      selector: `.a`,
+      expected: [0, 0, 1, 0],
+    },
+    {
+      selectorType: `attribute`,
+      selector: `[attr]`,
+      expected: [0, 0, 1, 0],
+    },
+    {
+      selectorType: `pseudo-class`,
+      selector: `:hover`,
+      expected: [0, 0, 1, 0],
+    },
+    {
+      selectorType: `id`,
+      selector: `#a`,
+      expected: [0, 1, 0, 0],
+    },
+    {
+      selectorType: `nested`,
+      selector: `&`,
+      expected: [0, 0, 0, 0],
+    },
+  ];
   describe(`basic selectors`, () => {
-    [
-      {
-        selectorType: `universal`,
-        selector: `*`,
-        expected: [0, 0, 0, 0],
-      },
-      {
-        selectorType: `type`,
-        selector: `span`,
-        expected: [0, 0, 0, 1],
-      },
-      {
-        selectorType: `pseudo-element`,
-        selector: `::before`,
-        expected: [0, 0, 0, 1],
-      },
-      {
-        selectorType: `class`,
-        selector: `.a`,
-        expected: [0, 0, 1, 0],
-      },
-      {
-        selectorType: `attribute`,
-        selector: `[attr]`,
-        expected: [0, 0, 1, 0],
-      },
-      {
-        selectorType: `pseudo-class`,
-        selector: `:hover`,
-        expected: [0, 0, 1, 0],
-      },
-      {
-        selectorType: `id`,
-        selector: `#a`,
-        expected: [0, 1, 0, 0],
-      },
-      {
-        selectorType: `nested`,
-        selector: `&`,
-        expected: [0, 0, 0, 0],
-      },
-    ].forEach(({ selectorType, selector, expected }) => {
+    basicSelectors.forEach(({ selectorType, selector, expected }) => {
       it(`should return correct specificity for ${selectorType} selector`, () => {
-        const specificity = calcSpecificity(parseCssSelector(selector));
+        const specificity = calcSpecificity(parseCssSelector(selector)[0]);
         expect(specificity).to.eql(expected);
       });
     });
   });
   describe(`special cases`, () => {
     it(`should only add the most specific inner selector for :not()`, () => {
-      const specificity = calcSpecificity(parseCssSelector(`:not(.a, #b)`));
+      const specificity = calcSpecificity(parseCssSelector(`:not(.a, #b)`)[0]);
       expect(specificity).to.eql([0, 1, 0, 0]);
     });
     it(`should only add the most specific inner selector for :is()`, () => {
-      const specificity = calcSpecificity(parseCssSelector(`:is(.a, #b)`));
+      const specificity = calcSpecificity(parseCssSelector(`:is(.a, #b)`)[0]);
       expect(specificity).to.eql([0, 1, 0, 0]);
     });
     it(`should only add the most specific inner selector for :has()`, () => {
-      const specificity = calcSpecificity(parseCssSelector(`:has(.a, #b)`));
+      const specificity = calcSpecificity(parseCssSelector(`:has(.a, #b)`)[0]);
       expect(specificity).to.eql([0, 1, 0, 0]);
     });
     it(`should add zero specificity for :where()`, () => {
-      const specificity = calcSpecificity(parseCssSelector(`:where(.a, #b)`));
+      const specificity = calcSpecificity(
+        parseCssSelector(`:where(.a, #b)`)[0]
+      );
       expect(specificity).to.eql([0, 0, 0, 0]);
     });
     it(`should add :nth-child pseudo-class plus the most specific inner selectors`, () => {
       const specificity = calcSpecificity(
-        parseCssSelector(`:nth-child(5n - 4 of .a, #b)`)
+        parseCssSelector(`:nth-child(5n - 4 of .a, #b)`)[0]
       );
       expect(specificity).to.eql([0, 1, 1, 0]);
     });
     it(`should add :nth-last-child pseudo-class plus the most specific inner selectors`, () => {
       const specificity = calcSpecificity(
-        parseCssSelector(`:nth-last-child(5n -4 of .a, #b)`)
+        parseCssSelector(`:nth-last-child(5n -4 of .a, #b)`)[0]
       );
       expect(specificity).to.eql([0, 1, 1, 0]);
     });
     it(`should add :nth-of-type pseudo-class plus the most specific inner selectors`, () => {
       const specificity = calcSpecificity(
-        parseCssSelector(`:nth-of-type(5n -4 of .a, #b)`)
+        parseCssSelector(`:nth-of-type(5n -4 of .a, #b)`)[0]
       );
       expect(specificity).to.eql([0, 1, 1, 0]);
     });
     it(`should add :nth-last-of-type pseudo-class plus the most specific inner selectors`, () => {
       const specificity = calcSpecificity(
-        parseCssSelector(`:nth-last-of-type(5n -4 of .a, #b)`)
+        parseCssSelector(`:nth-last-of-type(5n -4 of .a, #b)`)[0]
       );
       expect(specificity).to.eql([0, 1, 1, 0]);
     });
@@ -100,13 +104,13 @@ describe(`ast-tools/specificity`, () => {
   describe(`complex selectors`, () => {
     it(`should not add specificity for combinators`, () => {
       const specificity = calcSpecificity(
-        parseCssSelector(`.a + .b ~ .c > .d .e`)
+        parseCssSelector(`.a + .b ~ .c > .d .e`)[0]
       );
       expect(specificity).to.eql([0, 0, 5, 0]);
     });
     it(`should handle nested pseudo classes`, () => {
       const specificity = calcSpecificity(
-        parseCssSelector(`:is(:where(#zero), :has(:not(span, #a), .a))`)
+        parseCssSelector(`:is(:where(#zero), :has(:not(span, #a), .a))`)[0]
       );
       expect(specificity).to.eql([0, 1, 0, 0]);
     });
@@ -114,15 +118,31 @@ describe(`ast-tools/specificity`, () => {
       const specificity = calcSpecificity(
         parseCssSelector(
           `div(#a).x(#b)::y(#c)[attr](#d)&(#e)*(#f)#id(#g):unknown(#h)`
-        )
+        )[0]
       );
       expect(specificity).to.eql([0, 1, 3, 2]);
     });
     it(`should handle compound selector AST`, () => {
       const specificity = calcSpecificity(
-        groupCompoundSelectors(parseCssSelector(`.a .b`))
+        groupCompoundSelectors(parseCssSelector(`.a .b`)[0])
       );
       expect(specificity).to.eql([0, 0, 2, 0]);
+    });
+  });
+  describe(`accepted values`, () => {
+    basicSelectors.forEach(({ selectorType, selector, expected }) => {
+      it(`should accept ${selectorType} selector AST`, () => {
+        const basicNode = parseCssSelector(selector)[0].nodes[0];
+        const specificity = calcSpecificity(basicNode);
+        expect(specificity).to.eql(expected);
+      });
+    });
+    it(`should accept readonly value (type checks)`, () => {
+      const immutable = parseCssSelector(`.a .b`)[0] as ImmutableSelectorNode;
+      calcSpecificity(immutable);
+
+      const mutable = parseCssSelector(`.a .b`)[0];
+      calcSpecificity(mutable);
     });
   });
 });

--- a/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
+++ b/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
@@ -103,4 +103,12 @@ describe(`ast-tools/specificity`, () => {
     );
     expect(specificity).to.eql([0, 1, 0, 0]);
   });
+  it(`should not take non native functional selectors arguments into account`, () => {
+    const specificity = calcSpecificity(
+      parseCssSelector(
+        `div(#a).x(#b)::y(#c)[attr](#d)&(#e)*(#f)#id(#g):unknown(#h)`
+      )
+    );
+    expect(specificity).to.eql([0, 1, 3, 2]);
+  });
 });

--- a/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
+++ b/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
@@ -1,5 +1,6 @@
 import {
   calcSpecificity,
+  compareSpecificity,
   groupCompoundSelectors,
   parseCssSelector,
   ImmutableSelectorNode,
@@ -7,152 +8,190 @@ import {
 import { expect } from "chai";
 
 describe(`ast-tools/specificity`, () => {
-  const basicSelectors = [
-    {
-      selectorType: `universal`,
-      selector: `*`,
-      expected: [0, 0, 0, 0],
-    },
-    {
-      selectorType: `type`,
-      selector: `span`,
-      expected: [0, 0, 0, 1],
-    },
-    {
-      selectorType: `pseudo-element`,
-      selector: `::before`,
-      expected: [0, 0, 0, 1],
-    },
-    {
-      selectorType: `class`,
-      selector: `.a`,
-      expected: [0, 0, 1, 0],
-    },
-    {
-      selectorType: `attribute`,
-      selector: `[attr]`,
-      expected: [0, 0, 1, 0],
-    },
-    {
-      selectorType: `pseudo-class`,
-      selector: `:hover`,
-      expected: [0, 0, 1, 0],
-    },
-    {
-      selectorType: `id`,
-      selector: `#a`,
-      expected: [0, 1, 0, 0],
-    },
-    {
-      selectorType: `nested`,
-      selector: `&`,
-      expected: [0, 0, 0, 0],
-    },
-  ];
-  describe(`basic selectors`, () => {
-    basicSelectors.forEach(({ selectorType, selector, expected }) => {
-      it(`should return correct specificity for ${selectorType} selector`, () => {
-        const specificity = calcSpecificity(parseCssSelector(selector)[0]);
-        expect(specificity).to.eql(expected);
+  describe(`calcSpecificity`, () => {
+    const basicSelectors = [
+      {
+        selectorType: `universal`,
+        selector: `*`,
+        expected: [0, 0, 0, 0],
+      },
+      {
+        selectorType: `type`,
+        selector: `span`,
+        expected: [0, 0, 0, 1],
+      },
+      {
+        selectorType: `pseudo-element`,
+        selector: `::before`,
+        expected: [0, 0, 0, 1],
+      },
+      {
+        selectorType: `class`,
+        selector: `.a`,
+        expected: [0, 0, 1, 0],
+      },
+      {
+        selectorType: `attribute`,
+        selector: `[attr]`,
+        expected: [0, 0, 1, 0],
+      },
+      {
+        selectorType: `pseudo-class`,
+        selector: `:hover`,
+        expected: [0, 0, 1, 0],
+      },
+      {
+        selectorType: `id`,
+        selector: `#a`,
+        expected: [0, 1, 0, 0],
+      },
+      {
+        selectorType: `nested`,
+        selector: `&`,
+        expected: [0, 0, 0, 0],
+      },
+    ];
+    describe(`basic selectors`, () => {
+      basicSelectors.forEach(({ selectorType, selector, expected }) => {
+        it(`should return correct specificity for ${selectorType} selector`, () => {
+          const specificity = calcSpecificity(parseCssSelector(selector)[0]);
+          expect(specificity).to.eql(expected);
+        });
       });
     });
-  });
-  describe(`special cases`, () => {
-    it(`should only add the most specific inner selector for :not()`, () => {
-      const specificity = calcSpecificity(parseCssSelector(`:not(.a, #b)`)[0]);
-      expect(specificity).to.eql([0, 1, 0, 0]);
-    });
-    it(`should only add the most specific inner selector for :is()`, () => {
-      const specificity = calcSpecificity(parseCssSelector(`:is(.a, #b)`)[0]);
-      expect(specificity).to.eql([0, 1, 0, 0]);
-    });
-    it(`should only add the most specific inner selector for :has()`, () => {
-      const specificity = calcSpecificity(parseCssSelector(`:has(.a, #b)`)[0]);
-      expect(specificity).to.eql([0, 1, 0, 0]);
-    });
-    it(`should add zero specificity for :where()`, () => {
-      const specificity = calcSpecificity(
-        parseCssSelector(`:where(.a, #b)`)[0]
-      );
-      expect(specificity).to.eql([0, 0, 0, 0]);
-    });
-    it(`should add :nth-child pseudo-class plus the most specific inner selectors`, () => {
-      const specificity = calcSpecificity(
-        parseCssSelector(`:nth-child(5n - 4 of .a, #b)`)[0]
-      );
-      expect(specificity).to.eql([0, 1, 1, 0]);
-    });
-    it(`should add :nth-last-child pseudo-class plus the most specific inner selectors`, () => {
-      const specificity = calcSpecificity(
-        parseCssSelector(`:nth-last-child(5n -4 of .a, #b)`)[0]
-      );
-      expect(specificity).to.eql([0, 1, 1, 0]);
-    });
-    it(`should add :nth-of-type pseudo-class plus the most specific inner selectors`, () => {
-      const specificity = calcSpecificity(
-        parseCssSelector(`:nth-of-type(5n -4 of .a, #b)`)[0]
-      );
-      expect(specificity).to.eql([0, 1, 1, 0]);
-    });
-    it(`should add :nth-last-of-type pseudo-class plus the most specific inner selectors`, () => {
-      const specificity = calcSpecificity(
-        parseCssSelector(`:nth-last-of-type(5n -4 of .a, #b)`)[0]
-      );
-      expect(specificity).to.eql([0, 1, 1, 0]);
-    });
-  });
-  describe(`complex selectors`, () => {
-    it(`should not add specificity for combinators`, () => {
-      const specificity = calcSpecificity(
-        parseCssSelector(`.a + .b ~ .c > .d .e`)[0]
-      );
-      expect(specificity).to.eql([0, 0, 5, 0]);
-    });
-    it(`should handle nested pseudo classes`, () => {
-      const specificity = calcSpecificity(
-        parseCssSelector(`:is(:where(#zero), :has(:not(span, #a), .a))`)[0]
-      );
-      expect(specificity).to.eql([0, 1, 0, 0]);
-    });
-    it(`should not add specificity for comments`, () => {
-      const specificity = calcSpecificity(
-        parseCssSelector(`/*c1*/./*c2*/a/*c3*/`)[0]
-      );
-      expect(specificity).to.eql([0, 0, 1, 0]);
-    });
-    it(`should not add specificity for invalid`, () => {
-      const specificity = calcSpecificity(parseCssSelector(`:a(`)[0]);
-      expect(specificity).to.eql([0, 0, 1, 0]);
-    });
-    it(`should not take non native functional selectors arguments into account`, () => {
-      const specificity = calcSpecificity(
-        parseCssSelector(
-          `div(#a).x(#b)::y(#c)[attr](#d)&(#e)*(#f)#id(#g):unknown(#h)`
-        )[0]
-      );
-      expect(specificity).to.eql([0, 1, 3, 2]);
-    });
-    it(`should handle compound selector AST`, () => {
-      const specificity = calcSpecificity(
-        groupCompoundSelectors(parseCssSelector(`.a .b`)[0])
-      );
-      expect(specificity).to.eql([0, 0, 2, 0]);
-    });
-  });
-  describe(`accepted values`, () => {
-    basicSelectors.forEach(({ selectorType, selector, expected }) => {
-      it(`should accept ${selectorType} selector AST`, () => {
-        const basicNode = parseCssSelector(selector)[0].nodes[0];
-        const specificity = calcSpecificity(basicNode);
-        expect(specificity).to.eql(expected);
+    describe(`special cases`, () => {
+      it(`should only add the most specific inner selector for :not()`, () => {
+        const specificity = calcSpecificity(
+          parseCssSelector(`:not(.a, #b)`)[0]
+        );
+        expect(specificity).to.eql([0, 1, 0, 0]);
+      });
+      it(`should only add the most specific inner selector for :is()`, () => {
+        const specificity = calcSpecificity(parseCssSelector(`:is(.a, #b)`)[0]);
+        expect(specificity).to.eql([0, 1, 0, 0]);
+      });
+      it(`should only add the most specific inner selector for :has()`, () => {
+        const specificity = calcSpecificity(
+          parseCssSelector(`:has(.a, #b)`)[0]
+        );
+        expect(specificity).to.eql([0, 1, 0, 0]);
+      });
+      it(`should add zero specificity for :where()`, () => {
+        const specificity = calcSpecificity(
+          parseCssSelector(`:where(.a, #b)`)[0]
+        );
+        expect(specificity).to.eql([0, 0, 0, 0]);
+      });
+      it(`should add :nth-child pseudo-class plus the most specific inner selectors`, () => {
+        const specificity = calcSpecificity(
+          parseCssSelector(`:nth-child(5n - 4 of .a, #b)`)[0]
+        );
+        expect(specificity).to.eql([0, 1, 1, 0]);
+      });
+      it(`should add :nth-last-child pseudo-class plus the most specific inner selectors`, () => {
+        const specificity = calcSpecificity(
+          parseCssSelector(`:nth-last-child(5n -4 of .a, #b)`)[0]
+        );
+        expect(specificity).to.eql([0, 1, 1, 0]);
+      });
+      it(`should add :nth-of-type pseudo-class plus the most specific inner selectors`, () => {
+        const specificity = calcSpecificity(
+          parseCssSelector(`:nth-of-type(5n -4 of .a, #b)`)[0]
+        );
+        expect(specificity).to.eql([0, 1, 1, 0]);
+      });
+      it(`should add :nth-last-of-type pseudo-class plus the most specific inner selectors`, () => {
+        const specificity = calcSpecificity(
+          parseCssSelector(`:nth-last-of-type(5n -4 of .a, #b)`)[0]
+        );
+        expect(specificity).to.eql([0, 1, 1, 0]);
       });
     });
-    it(`should accept readonly value (type checks)`, () => {
-      const immutable = parseCssSelector(`.a .b`)[0] as ImmutableSelectorNode;
-      calcSpecificity(immutable);
+    describe(`complex selectors`, () => {
+      it(`should not add specificity for combinators`, () => {
+        const specificity = calcSpecificity(
+          parseCssSelector(`.a + .b ~ .c > .d .e`)[0]
+        );
+        expect(specificity).to.eql([0, 0, 5, 0]);
+      });
+      it(`should handle nested pseudo classes`, () => {
+        const specificity = calcSpecificity(
+          parseCssSelector(`:is(:where(#zero), :has(:not(span, #a), .a))`)[0]
+        );
+        expect(specificity).to.eql([0, 1, 0, 0]);
+      });
+      it(`should not add specificity for comments`, () => {
+        const specificity = calcSpecificity(
+          parseCssSelector(`/*c1*/./*c2*/a/*c3*/`)[0]
+        );
+        expect(specificity).to.eql([0, 0, 1, 0]);
+      });
+      it(`should not add specificity for invalid`, () => {
+        const specificity = calcSpecificity(parseCssSelector(`:a(`)[0]);
+        expect(specificity).to.eql([0, 0, 1, 0]);
+      });
+      it(`should not take non native functional selectors arguments into account`, () => {
+        const specificity = calcSpecificity(
+          parseCssSelector(
+            `div(#a).x(#b)::y(#c)[attr](#d)&(#e)*(#f)#id(#g):unknown(#h)`
+          )[0]
+        );
+        expect(specificity).to.eql([0, 1, 3, 2]);
+      });
+      it(`should handle compound selector AST`, () => {
+        const specificity = calcSpecificity(
+          groupCompoundSelectors(parseCssSelector(`.a .b`)[0])
+        );
+        expect(specificity).to.eql([0, 0, 2, 0]);
+      });
+    });
+    describe(`accepted values`, () => {
+      basicSelectors.forEach(({ selectorType, selector, expected }) => {
+        it(`should accept ${selectorType} selector AST`, () => {
+          const basicNode = parseCssSelector(selector)[0].nodes[0];
+          const specificity = calcSpecificity(basicNode);
+          expect(specificity).to.eql(expected);
+        });
+      });
+      it(`should accept readonly value (type checks)`, () => {
+        const immutable = parseCssSelector(`.a .b`)[0] as ImmutableSelectorNode;
+        calcSpecificity(immutable);
 
-      const mutable = parseCssSelector(`.a .b`)[0];
-      calcSpecificity(mutable);
+        const mutable = parseCssSelector(`.a .b`)[0];
+        calcSpecificity(mutable);
+      });
+    });
+  });
+  describe(`compareSpecificity`, () => {
+    it(`should return 0 when equal`, () => {
+      expect(
+        compareSpecificity([0, 0, 0, 0], [0, 0, 0, 0]),
+        `all zeros`
+      ).to.equal(0);
+      expect(
+        compareSpecificity([5, 4, 3, 2], [5, 4, 3, 2]),
+        `complex`
+      ).to.equal(0);
+    });
+    it(`should return 1 when first specificity is higher`, () => {
+      expect(
+        compareSpecificity([1, 0, 0, 0], [0, 9, 0, 0]),
+        `higher place`
+      ).to.equal(1);
+      expect(
+        compareSpecificity([0, 5, 0, 0], [0, 4, 0, 0]),
+        `higher value`
+      ).to.equal(1);
+    });
+    it(`should return -1 when second specificity is higher`, () => {
+      expect(
+        compareSpecificity([0, 9, 0, 0], [1, 0, 0, 0]),
+        `higher place`
+      ).to.equal(-1);
+      expect(
+        compareSpecificity([0, 4, 0, 0], [0, 5, 0, 0]),
+        `higher value`
+      ).to.equal(-1);
     });
   });
 });

--- a/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
+++ b/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
@@ -108,6 +108,12 @@ describe(`ast-tools/specificity`, () => {
       );
       expect(specificity).to.eql([0, 0, 5, 0]);
     });
+    it(`should not add specificity for comments`, () => {
+      const specificity = calcSpecificity(
+        parseCssSelector(`/*c1*/./*c2*/a/*c3*/`)[0]
+      );
+      expect(specificity).to.eql([0, 0, 1, 0]);
+    });
     it(`should handle nested pseudo classes`, () => {
       const specificity = calcSpecificity(
         parseCssSelector(`:is(:where(#zero), :has(:not(span, #a), .a))`)[0]

--- a/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
+++ b/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
@@ -69,7 +69,7 @@ describe(`ast-tools/specificity`, () => {
     const specificity = calcSpecificity(parseCssSelector(`:has(.a, #b)`));
     expect(specificity).to.eql([0, 1, 0, 0]);
   });
-  it(`should not zero specificity for :where()`, () => {
+  it(`should add zero specificity for :where()`, () => {
     const specificity = calcSpecificity(parseCssSelector(`:where(.a, #b)`));
     expect(specificity).to.eql([0, 0, 0, 0]);
   });

--- a/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
+++ b/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
@@ -51,64 +51,68 @@ describe(`ast-tools/specificity`, () => {
       });
     });
   });
-  it(`should not add specificity for combinators`, () => {
-    const specificity = calcSpecificity(
-      parseCssSelector(`.a + .b ~ .c > .d .e`)
-    );
-    expect(specificity).to.eql([0, 0, 5, 0]);
+  describe(`special cases`, () => {
+    it(`should only add the most specific inner selector for :not()`, () => {
+      const specificity = calcSpecificity(parseCssSelector(`:not(.a, #b)`));
+      expect(specificity).to.eql([0, 1, 0, 0]);
+    });
+    it(`should only add the most specific inner selector for :is()`, () => {
+      const specificity = calcSpecificity(parseCssSelector(`:is(.a, #b)`));
+      expect(specificity).to.eql([0, 1, 0, 0]);
+    });
+    it(`should only add the most specific inner selector for :has()`, () => {
+      const specificity = calcSpecificity(parseCssSelector(`:has(.a, #b)`));
+      expect(specificity).to.eql([0, 1, 0, 0]);
+    });
+    it(`should add zero specificity for :where()`, () => {
+      const specificity = calcSpecificity(parseCssSelector(`:where(.a, #b)`));
+      expect(specificity).to.eql([0, 0, 0, 0]);
+    });
+    it(`should add :nth-child pseudo-class plus the most specific inner selectors`, () => {
+      const specificity = calcSpecificity(
+        parseCssSelector(`:nth-child(5n - 4 of .a, #b)`)
+      );
+      expect(specificity).to.eql([0, 1, 1, 0]);
+    });
+    it(`should add :nth-last-child pseudo-class plus the most specific inner selectors`, () => {
+      const specificity = calcSpecificity(
+        parseCssSelector(`:nth-last-child(5n -4 of .a, #b)`)
+      );
+      expect(specificity).to.eql([0, 1, 1, 0]);
+    });
+    it(`should add :nth-of-type pseudo-class plus the most specific inner selectors`, () => {
+      const specificity = calcSpecificity(
+        parseCssSelector(`:nth-of-type(5n -4 of .a, #b)`)
+      );
+      expect(specificity).to.eql([0, 1, 1, 0]);
+    });
+    it(`should add :nth-last-of-type pseudo-class plus the most specific inner selectors`, () => {
+      const specificity = calcSpecificity(
+        parseCssSelector(`:nth-last-of-type(5n -4 of .a, #b)`)
+      );
+      expect(specificity).to.eql([0, 1, 1, 0]);
+    });
   });
-  it(`should only add the most specific inner selector for :not()`, () => {
-    const specificity = calcSpecificity(parseCssSelector(`:not(.a, #b)`));
-    expect(specificity).to.eql([0, 1, 0, 0]);
-  });
-  it(`should only add the most specific inner selector for :is()`, () => {
-    const specificity = calcSpecificity(parseCssSelector(`:is(.a, #b)`));
-    expect(specificity).to.eql([0, 1, 0, 0]);
-  });
-  it(`should only add the most specific inner selector for :has()`, () => {
-    const specificity = calcSpecificity(parseCssSelector(`:has(.a, #b)`));
-    expect(specificity).to.eql([0, 1, 0, 0]);
-  });
-  it(`should add zero specificity for :where()`, () => {
-    const specificity = calcSpecificity(parseCssSelector(`:where(.a, #b)`));
-    expect(specificity).to.eql([0, 0, 0, 0]);
-  });
-  it(`should add :nth-child pseudo-class plus the most specific inner selectors`, () => {
-    const specificity = calcSpecificity(
-      parseCssSelector(`:nth-child(5n - 4 of .a, #b)`)
-    );
-    expect(specificity).to.eql([0, 1, 1, 0]);
-  });
-  it(`should add :nth-last-child pseudo-class plus the most specific inner selectors`, () => {
-    const specificity = calcSpecificity(
-      parseCssSelector(`:nth-last-child(5n -4 of .a, #b)`)
-    );
-    expect(specificity).to.eql([0, 1, 1, 0]);
-  });
-  it(`should add :nth-of-type pseudo-class plus the most specific inner selectors`, () => {
-    const specificity = calcSpecificity(
-      parseCssSelector(`:nth-of-type(5n -4 of .a, #b)`)
-    );
-    expect(specificity).to.eql([0, 1, 1, 0]);
-  });
-  it(`should add :nth-last-of-type pseudo-class plus the most specific inner selectors`, () => {
-    const specificity = calcSpecificity(
-      parseCssSelector(`:nth-last-of-type(5n -4 of .a, #b)`)
-    );
-    expect(specificity).to.eql([0, 1, 1, 0]);
-  });
-  it(`should handle nested pseudo classes`, () => {
-    const specificity = calcSpecificity(
-      parseCssSelector(`:is(:where(#zero), :has(:not(span, #a), .a))`)
-    );
-    expect(specificity).to.eql([0, 1, 0, 0]);
-  });
-  it(`should not take non native functional selectors arguments into account`, () => {
-    const specificity = calcSpecificity(
-      parseCssSelector(
-        `div(#a).x(#b)::y(#c)[attr](#d)&(#e)*(#f)#id(#g):unknown(#h)`
-      )
-    );
-    expect(specificity).to.eql([0, 1, 3, 2]);
+  describe(`complex selectors`, () => {
+    it(`should not add specificity for combinators`, () => {
+      const specificity = calcSpecificity(
+        parseCssSelector(`.a + .b ~ .c > .d .e`)
+      );
+      expect(specificity).to.eql([0, 0, 5, 0]);
+    });
+    it(`should handle nested pseudo classes`, () => {
+      const specificity = calcSpecificity(
+        parseCssSelector(`:is(:where(#zero), :has(:not(span, #a), .a))`)
+      );
+      expect(specificity).to.eql([0, 1, 0, 0]);
+    });
+    it(`should not take non native functional selectors arguments into account`, () => {
+      const specificity = calcSpecificity(
+        parseCssSelector(
+          `div(#a).x(#b)::y(#c)[attr](#d)&(#e)*(#f)#id(#g):unknown(#h)`
+        )
+      );
+      expect(specificity).to.eql([0, 1, 3, 2]);
+    });
   });
 });

--- a/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
+++ b/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
@@ -144,6 +144,12 @@ describe(`ast-tools/specificity`, () => {
         );
         expect(specificity).to.eql([0, 0, 2, 0]);
       });
+      it(`should handle empty functional selector`, () => {
+        const specificity = calcSpecificity(
+          groupCompoundSelectors(parseCssSelector(`div:not()`)[0])
+        );
+        expect(specificity).to.eql([0, 0, 0, 1]);
+      });
     });
     describe(`accepted values`, () => {
       basicSelectors.forEach(({ selectorType, selector, expected }) => {

--- a/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
+++ b/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
@@ -1,4 +1,8 @@
-import { calcSpecificity, parseCssSelector } from "@tokey/css-selector-parser";
+import {
+  calcSpecificity,
+  groupCompoundSelectors,
+  parseCssSelector,
+} from "@tokey/css-selector-parser";
 import { expect } from "chai";
 
 describe(`ast-tools/specificity`, () => {
@@ -113,6 +117,12 @@ describe(`ast-tools/specificity`, () => {
         )
       );
       expect(specificity).to.eql([0, 1, 3, 2]);
+    });
+    it(`should handle compound selector AST`, () => {
+      const specificity = calcSpecificity(
+        groupCompoundSelectors(parseCssSelector(`.a .b`))
+      );
+      expect(specificity).to.eql([0, 0, 2, 0]);
     });
   });
 });

--- a/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
+++ b/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
@@ -1,0 +1,101 @@
+import { calcSpecificity, parseCssSelector } from "@tokey/css-selector-parser";
+import { expect } from "chai";
+
+describe(`ast-tools/specificity`, () => {
+  describe(`basic selectors`, () => {
+    [
+      {
+        selectorType: `universal`,
+        selector: `*`,
+        expected: [0, 0, 0, 0],
+      },
+      {
+        selectorType: `type`,
+        selector: `span`,
+        expected: [0, 0, 0, 1],
+      },
+      {
+        selectorType: `pseudo-element`,
+        selector: `::before`,
+        expected: [0, 0, 0, 1],
+      },
+      {
+        selectorType: `class`,
+        selector: `.a`,
+        expected: [0, 0, 1, 0],
+      },
+      {
+        selectorType: `attribute`,
+        selector: `[attr]`,
+        expected: [0, 0, 1, 0],
+      },
+      {
+        selectorType: `pseudo-class`,
+        selector: `:hover`,
+        expected: [0, 0, 1, 0],
+      },
+      {
+        selectorType: `id`,
+        selector: `#a`,
+        expected: [0, 1, 0, 0],
+      },
+    ].forEach(({ selectorType, selector, expected }) => {
+      it(`should return correct specificity for ${selectorType} selector`, () => {
+        const specificity = calcSpecificity(parseCssSelector(selector));
+        expect(specificity).to.eql(expected);
+      });
+    });
+  });
+  it(`should not add specificity for combinators`, () => {
+    const specificity = calcSpecificity(
+      parseCssSelector(`.a + .b ~ .c > .d .e`)
+    );
+    expect(specificity).to.eql([0, 0, 5, 0]);
+  });
+  it(`should only add the most specific inner selector for :not()`, () => {
+    const specificity = calcSpecificity(parseCssSelector(`:not(.a, #b)`));
+    expect(specificity).to.eql([0, 1, 0, 0]);
+  });
+  it(`should only add the most specific inner selector for :is()`, () => {
+    const specificity = calcSpecificity(parseCssSelector(`:is(.a, #b)`));
+    expect(specificity).to.eql([0, 1, 0, 0]);
+  });
+  it(`should only add the most specific inner selector for :has()`, () => {
+    const specificity = calcSpecificity(parseCssSelector(`:has(.a, #b)`));
+    expect(specificity).to.eql([0, 1, 0, 0]);
+  });
+  it(`should not zero specificity for :where()`, () => {
+    const specificity = calcSpecificity(parseCssSelector(`:where(.a, #b)`));
+    expect(specificity).to.eql([0, 0, 0, 0]);
+  });
+  it(`should add :nth-child pseudo-class plus the most specific inner selectors`, () => {
+    const specificity = calcSpecificity(
+      parseCssSelector(`:nth-child(5n - 4 of .a, #b)`)
+    );
+    expect(specificity).to.eql([0, 1, 1, 0]);
+  });
+  it(`should add :nth-last-child pseudo-class plus the most specific inner selectors`, () => {
+    const specificity = calcSpecificity(
+      parseCssSelector(`:nth-last-child(5n -4 of .a, #b)`)
+    );
+    expect(specificity).to.eql([0, 1, 1, 0]);
+  });
+  it(`should add :nth-of-type pseudo-class plus the most specific inner selectors`, () => {
+    const specificity = calcSpecificity(
+      parseCssSelector(`:nth-of-type(5n -4 of .a, #b)`)
+    );
+    expect(specificity).to.eql([0, 1, 1, 0]);
+  });
+  it(`should add :nth-last-of-type pseudo-class plus the most specific inner selectors`, () => {
+    const specificity = calcSpecificity(
+      parseCssSelector(`:nth-last-of-type(5n -4 of .a, #b)`)
+    );
+    expect(specificity).to.eql([0, 1, 1, 0]);
+  });
+  it(`should handle nested pseudo classes`, () => {
+    const specificity = calcSpecificity(
+      parseCssSelector(`:is(:where(#zero), :has(:not(span, #a), .a))`)
+    );
+    expect(specificity).to.eql([0, 1, 0, 0]);
+  });
+});

--- a/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
+++ b/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
@@ -108,17 +108,21 @@ describe(`ast-tools/specificity`, () => {
       );
       expect(specificity).to.eql([0, 0, 5, 0]);
     });
+    it(`should handle nested pseudo classes`, () => {
+      const specificity = calcSpecificity(
+        parseCssSelector(`:is(:where(#zero), :has(:not(span, #a), .a))`)[0]
+      );
+      expect(specificity).to.eql([0, 1, 0, 0]);
+    });
     it(`should not add specificity for comments`, () => {
       const specificity = calcSpecificity(
         parseCssSelector(`/*c1*/./*c2*/a/*c3*/`)[0]
       );
       expect(specificity).to.eql([0, 0, 1, 0]);
     });
-    it(`should handle nested pseudo classes`, () => {
-      const specificity = calcSpecificity(
-        parseCssSelector(`:is(:where(#zero), :has(:not(span, #a), .a))`)[0]
-      );
-      expect(specificity).to.eql([0, 1, 0, 0]);
+    it(`should not add specificity for invalid`, () => {
+      const specificity = calcSpecificity(parseCssSelector(`:a(`)[0]);
+      expect(specificity).to.eql([0, 0, 1, 0]);
     });
     it(`should not take non native functional selectors arguments into account`, () => {
       const specificity = calcSpecificity(

--- a/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
+++ b/packages/css-selector-parser/test/ast-tools/specificity.spec.ts
@@ -39,6 +39,11 @@ describe(`ast-tools/specificity`, () => {
         selector: `#a`,
         expected: [0, 1, 0, 0],
       },
+      {
+        selectorType: `nested`,
+        selector: `&`,
+        expected: [0, 0, 0, 0],
+      },
     ].forEach(({ selectorType, selector, expected }) => {
       it(`should return correct specificity for ${selectorType} selector`, () => {
         const specificity = calcSpecificity(parseCssSelector(selector));


### PR DESCRIPTION
This PR adds `calcSpecificity` exported function to `@tokey/css-selector-parser` that accepts selector AST and returns a tuple of [specificity](https://www.w3.org/TR/selectors-4/#specificity-rules) and an helper `compareSpecificity` function to compare 2 specificity values.

- [x] base selectors: `*, type, ::pseudo-element, .class, [attribute], :pseudo-class, #id, &`
- [x] inner most specific selector: `:not(), :is(), :has()` 
- [x] zero specificity: `:where()`, combinators, An+B...
- [x]  pseudo-class + most specific selector: `:nth-child(), :nth-last-child(), :nth-of-type(), :nth-last-of-type()`
- [x] non native functional selectors ignore arguments specificity
- ~browser prefixes~ - no such prefixes for any special case
- [x] immutable / mutable input type test
- [x] inner AST input support: `Selector | SelectorNode`
- [x] `compareSpecificity` function
- [x] documentation