### PR TITLE
fix wrong index for filtered walk traversal

### DIFF
--- a/packages/css-selector-parser/src/ast-tools/walk.ts
+++ b/packages/css-selector-parser/src/ast-tools/walk.ts
@@ -74,8 +74,6 @@ export function walk<
           context.nodesInSelector as SelectorNode[],
           context.parents as SelectorNode[]
         ) as number) ?? -1;
-      // point to next selector node
-      context.next();
       // check if to skip nested or current/following selectors
       if (skipAmount === Infinity) {
         // stop all: fast bail out
@@ -92,6 +90,8 @@ export function walk<
         continue;
       }
     }
+    // point to next selector node
+    context.next();
     // add nested nodes
     if (isWithNodes(current)) {
       context.insertNested(current);

--- a/packages/css-selector-parser/test/ast-tools/walk.spec.ts
+++ b/packages/css-selector-parser/test/ast-tools/walk.spec.ts
@@ -79,10 +79,10 @@ describe(`ast-tools/walk`, () => {
       walkOptions: {
         ignoreList: ["selector", `id`],
       },
-      mapVisit: ({ type, value }: any) => ({ type, value }),
+      mapVisit: ({ type, value }: any, index) => ({ type, value, index }),
       expectedMap: [
-        { type: `class`, value: `a` },
-        { type: `class`, value: `c` },
+        { type: `class`, value: `a`, index: 0 },
+        { type: `class`, value: `c`, index: 2 },
       ],
     });
   });
@@ -91,10 +91,10 @@ describe(`ast-tools/walk`, () => {
       walkOptions: {
         visitList: [`id`],
       },
-      mapVisit: ({ type, value }: any) => ({ type, value }),
+      mapVisit: ({ type, value }: any, index) => ({ type, value, index }),
       expectedMap: [
-        { type: `id`, value: `b` },
-        { type: `id`, value: `d` },
+        { type: `id`, value: `b`, index: 1 },
+        { type: `id`, value: `d`, index: 4 },
       ],
     });
   });


### PR DESCRIPTION
This PR fixes #44 bug that caused the index of the visitor to be wrong when used with `allowList` or `ignoreList`.