### PR TITLE
fix(css-value-parser): custom ident that ends with number

### DIFF
--- a/packages/css-value-parser/src/value-parser.ts
+++ b/packages/css-value-parser/src/value-parser.ts
@@ -370,7 +370,7 @@ function isNumber(value: string) {
     return !!numVal && numVal === value;
 }
 function isStartOfNumber(value: string): false | [number: string, leftover: string] {
-    const match = value.match(new RegExp(validNumberRegex, `i`));
+    const match = value.match(new RegExp(`^(` + validNumberRegex + `)`, `i`));
     const numVal = match?.[0];
     return numVal ? [numVal, value.substring(numVal.length)] : false;
 }

--- a/packages/css-value-parser/test/value-parser.spec.ts
+++ b/packages/css-value-parser/test/value-parser.spec.ts
@@ -157,6 +157,18 @@ describe(`value-parser`, () => {
                         }),
                     ],
                 },
+                {
+                    type: `<custom-ident>`,
+                    desc: `end with number`,
+                    source: `abc5`,
+                    expected: [
+                        customIdent({
+                            value: `abc5`,
+                            start: 0,
+                            end: 4,
+                        }),
+                    ],
+                },
             ].forEach(createTest);
         });
         describe(`dashed-ident`, () => {


### PR DESCRIPTION
This PR fixes parsing of custom ident that ends with number: `abc5`