### PR TITLE
fix: split ident by dot

### DIFF
--- a/packages/css-value-parser/src/tokenizer.ts
+++ b/packages/css-value-parser/src/tokenizer.ts
@@ -10,7 +10,7 @@ import {
 } from '@tokey/core';
 import type { Token, Descriptors } from '@tokey/core';
 
-type Delimiters = '(' | ')' | ',' | '/' | '+' | '-' | '*' | '#';
+type Delimiters = '(' | ')' | ',' | '/' | '+' | '-' | '*' | '#' | '.';
 
 export type CSSValueToken = Token<Descriptors | Delimiters>;
 
@@ -42,4 +42,5 @@ const isDelimiter = (char: string, previousChar: string) =>
         char === '+' ||
         char === '-' ||
         char === '*' ||
-        char === '#');
+        char === '#' ||
+        char === '.');

--- a/packages/css-value-parser/src/value-parser.ts
+++ b/packages/css-value-parser/src/value-parser.ts
@@ -178,6 +178,18 @@ function handleToken(
                 })
             );
         }
+    } else if (type === '.') {
+        if (parseNumber(token, ast, source, s)) {
+            // number parsed
+        } else {
+            ast.push(
+                literal({
+                    start,
+                    end,
+                    value,
+                })
+            );
+        }
     } else if (isComment(type)) {
         ast.push(
             comment({
@@ -255,7 +267,12 @@ function parseNumber(
     if (!numberUnit) {
         // collect potential extra number parts
         let nextToken = s.peek(peekCount);
-        while (nextToken.type === `-` || nextToken.type === `+` || nextToken.type === `text`) {
+        while (
+            nextToken.type === `-` ||
+            nextToken.type === `+` ||
+            nextToken.type === `.` ||
+            nextToken.type === `text`
+        ) {
             const nextValue = numberValue + nextToken.value;
             // const validNumber = isNumber(nextValue);
             startMatch = isStartOfNumber(nextValue);
@@ -347,12 +364,13 @@ const knownUnits = {
     }, {} as Record<typeof resolutionValidUnits[number], typeof resolution>),
 } as const;
 
-const NumberRegExp = /[-+]?(\d+\.?\d*|\d*\.?\d+)(e[-+]?\d+)?/i;
+const NumberRegExp = /^[-+]?(\d+\.?\d*|\d*\.?\d+)(e[-+]?\d+)?/i;
 const integerRegExp = /^[-+]?\d+$/i; // one or more decimal digits 0 through 9 (preceded by -/+ ) - https://www.w3.org/TR/css-values-4/#integer-value
 const validNumberRegex = [
     /[-+]?(\d+\.?\d*|\d*\.?\d+)(e[-+]?\d*)?/, // float+exponential
     /[-+]?\d+(e[-+]?\d*)?/, // int+exponential
     /[-+]/, // sign
+    /[-+]?\./, // optional-sign+dot
 ]
     .map((r) => r.source)
     .join(`|`); // join with one-of ("or")

--- a/packages/css-value-parser/test/value-parser.spec.ts
+++ b/packages/css-value-parser/test/value-parser.spec.ts
@@ -92,6 +92,11 @@ describe(`value-parser`, () => {
                 source: `(`,
                 expected: [literal({ value: `(`, start: 0, end: 1 })],
             },
+            {
+                type: `.`,
+                source: `.`,
+                expected: [literal({ value: `.`, start: 0, end: 1 })],
+            },
         ].forEach(createTest);
     });
     describe(`css-wide-keyword`, () => {
@@ -166,6 +171,24 @@ describe(`value-parser`, () => {
                             value: `abc5`,
                             start: 0,
                             end: 4,
+                        }),
+                    ],
+                },
+                {
+                    type: `<custom-ident>`,
+                    desc: `separated by dots`,
+                    source: `abc.xyz`,
+                    expected: [
+                        customIdent({
+                            value: `abc`,
+                            start: 0,
+                            end: 3,
+                        }),
+                        literal({ value: `.`, start: 3, end: 4 }),
+                        customIdent({
+                            value: `xyz`,
+                            start: 4,
+                            end: 7,
                         }),
                     ],
                 },


### PR DESCRIPTION
This PR fix ident parse bug that take `.` (dot) as part of an ident token.