### PR TITLE
fix(import-tkn): unhandled error on missing source

### DIFF
--- a/packages/imports-parser/src/imports-parser.ts
+++ b/packages/imports-parser/src/imports-parser.ts
@@ -172,6 +172,7 @@ function findImports(
                 if (t.type === 'string') {
                     from = t.value.slice(1, -1);
                 } else {
+                    s.back();
                     errors.push('invalid missing source');
                 }
             }

--- a/packages/imports-parser/test/import-tokenizer.spec.ts
+++ b/packages/imports-parser/test/import-tokenizer.spec.ts
@@ -284,6 +284,22 @@ describe(`demos/import-tokenizer`, () => {
                 ],
             });
         });
+        it(`import {a}`, () => {
+            test(`import {a}`, {
+                expectedAst: [
+                    createImportValue({
+                        star: false,
+                        named: { a: 'a' },
+                        tagged: {},
+                        from: undefined,
+                        defaultName: undefined,
+                        errors: ['invalid missing from', 'invalid missing source'],
+                        start: 0,
+                        end: 10,
+                    }),
+                ],
+            });
+        });
         it(`import {a as, b} "x"`, () => {
             // this case can be better by reporting missing name after as
             test(`import {a as, b} "x"`, {


### PR DESCRIPTION
This PR fixes an unhandled error for an import input with no "from source".

The issue was a check for source specifier that moves the seeker index to overflow without moving it back.