### PR TITLE
fix(import-tkn)!: preserve named imports 

### DIFF
--- a/packages/imports-parser/test/import-tokenizer.spec.ts
+++ b/packages/imports-parser/test/import-tokenizer.spec.ts
@@ -22,7 +22,7 @@ describe(`demos/import-tokenizer`, () => {
                 createImportValue({
                     star: false,
                     named: undefined,
-                    tagged: undefined,
+                    tagged: {},
                     from: 'x',
                     defaultName: undefined,
                     errors: [],
@@ -39,7 +39,7 @@ describe(`demos/import-tokenizer`, () => {
                 createImportValue({
                     star: false,
                     named: undefined,
-                    tagged: undefined,
+                    tagged: {},
                     from: 'x',
                     defaultName: undefined,
                     errors: [],
@@ -55,7 +55,7 @@ describe(`demos/import-tokenizer`, () => {
                 createImportValue({
                     star: false,
                     named: undefined,
-                    tagged: undefined,
+                    tagged: {},
                     from: 'x',
                     defaultName: undefined,
                     errors: ['missing semicolon'],
@@ -65,7 +65,7 @@ describe(`demos/import-tokenizer`, () => {
                 createImportValue({
                     star: false,
                     named: undefined,
-                    tagged: undefined,
+                    tagged: {},
                     from: 'y',
                     defaultName: undefined,
                     errors: [],
@@ -81,7 +81,7 @@ describe(`demos/import-tokenizer`, () => {
                 createImportValue({
                     star: false,
                     named: undefined,
-                    tagged: undefined,
+                    tagged: {},
                     from: 'x',
                     defaultName: undefined,
                     errors: [],
@@ -97,7 +97,7 @@ describe(`demos/import-tokenizer`, () => {
                 createImportValue({
                     star: false,
                     named: undefined,
-                    tagged: undefined,
+                    tagged: {},
                     from: 'x',
                     defaultName: undefined,
                     errors: [],
@@ -113,7 +113,7 @@ describe(`demos/import-tokenizer`, () => {
                 createImportValue({
                     star: false,
                     named: undefined,
-                    tagged: undefined,
+                    tagged: {},
                     from: 'x',
                     defaultName: undefined,
                     errors: [],
@@ -129,7 +129,7 @@ describe(`demos/import-tokenizer`, () => {
                 createImportValue({
                     star: false,
                     named: undefined,
-                    tagged: undefined,
+                    tagged: {},
                     from: 'x',
                     defaultName: undefined,
                     errors: [],
@@ -145,7 +145,7 @@ describe(`demos/import-tokenizer`, () => {
                 createImportValue({
                     star: false,
                     named: undefined,
-                    tagged: undefined,
+                    tagged: {},
                     from: 'x',
                     defaultName: 'name',
                     errors: [],
@@ -160,7 +160,7 @@ describe(`demos/import-tokenizer`, () => {
             expectedAst: [
                 createImportValue({
                     star: false,
-                    named: { named: 'named' },
+                    named: [['named', 'named']],
                     tagged: {},
                     from: 'x',
                     defaultName: undefined,
@@ -176,7 +176,7 @@ describe(`demos/import-tokenizer`, () => {
             expectedAst: [
                 createImportValue({
                     star: false,
-                    named: { named: 'renamed' },
+                    named: [['named', 'renamed']],
                     tagged: {},
                     from: 'x',
                     defaultName: undefined,
@@ -187,12 +187,31 @@ describe(`demos/import-tokenizer`, () => {
             ],
         });
     });
+    it(`import {x, x as local-x} from "x"`, () => {
+        test(`import {x, x as local-x} from "x"`, {
+            expectedAst: [
+                createImportValue({
+                    star: false,
+                    named: [
+                        ['x', 'x'],
+                        ['x', 'local-x'],
+                    ],
+                    tagged: {},
+                    from: 'x',
+                    defaultName: undefined,
+                    errors: [],
+                    start: 0,
+                    end: 33,
+                }),
+            ],
+        });
+    });
     it(`import name, {named} from "x"`, () => {
         test(`import name, {named} from "x"`, {
             expectedAst: [
                 createImportValue({
                     star: false,
-                    named: { named: 'named' },
+                    named: [['named', 'named']],
                     tagged: {},
                     from: 'x',
                     defaultName: 'name',
@@ -209,7 +228,7 @@ describe(`demos/import-tokenizer`, () => {
                 createImportValue({
                     star: true,
                     named: undefined,
-                    tagged: undefined,
+                    tagged: {},
                     from: 'x',
                     defaultName: 'name',
                     errors: [],
@@ -224,7 +243,10 @@ describe(`demos/import-tokenizer`, () => {
             expectedAst: [
                 createImportValue({
                     star: false,
-                    named: { named1: 'named1', named2: 'named2' },
+                    named: [
+                        ['named1', 'named1'],
+                        ['named2', 'named2'],
+                    ],
                     tagged: {},
                     from: 'x',
                     defaultName: undefined,
@@ -240,7 +262,7 @@ describe(`demos/import-tokenizer`, () => {
             expectedAst: [
                 createImportValue({
                     star: false,
-                    named: { named: 'named' },
+                    named: [['named', 'named']],
                     tagged: {},
                     from: 'x',
                     defaultName: undefined,
@@ -258,7 +280,7 @@ describe(`demos/import-tokenizer`, () => {
                     createImportValue({
                         star: true,
                         named: undefined,
-                        tagged: undefined,
+                        tagged: {},
                         from: 'x',
                         defaultName: undefined,
                         errors: ['expected as after *'],
@@ -274,7 +296,7 @@ describe(`demos/import-tokenizer`, () => {
                     createImportValue({
                         star: true,
                         named: undefined,
-                        tagged: undefined,
+                        tagged: {},
                         from: 'x',
                         defaultName: undefined,
                         errors: ['expected as after *', 'invalid missing from'],
@@ -290,7 +312,7 @@ describe(`demos/import-tokenizer`, () => {
                 expectedAst: [
                     createImportValue({
                         star: false,
-                        named: { b: 'b' },
+                        named: [['b', 'b']],
                         tagged: {},
                         from: 'x',
                         defaultName: undefined,
@@ -308,7 +330,7 @@ describe(`demos/import-tokenizer`, () => {
                     createImportValue({
                         star: false,
                         named: undefined,
-                        tagged: undefined,
+                        tagged: {},
                         from: 'x',
                         defaultName: undefined,
                         errors: ['unclosed block'],
@@ -324,7 +346,7 @@ describe(`demos/import-tokenizer`, () => {
                     createImportValue({
                         star: false,
                         named: undefined,
-                        tagged: undefined,
+                        tagged: {},
                         from: undefined,
                         defaultName: undefined,
                         errors: [
@@ -338,7 +360,7 @@ describe(`demos/import-tokenizer`, () => {
                     createImportValue({
                         star: false,
                         named: undefined,
-                        tagged: undefined,
+                        tagged: {},
                         from: 'y',
                         defaultName: undefined,
                         errors: [],
@@ -354,7 +376,7 @@ describe(`demos/import-tokenizer`, () => {
                     createImportValue({
                         star: false,
                         named: undefined,
-                        tagged: undefined,
+                        tagged: {},
                         from: 'x',
                         defaultName: undefined,
                         errors: ['missing name'],
@@ -369,7 +391,7 @@ describe(`demos/import-tokenizer`, () => {
                 expectedAst: [
                     createImportValue({
                         star: true,
-                        named: { a: 'a' },
+                        named: [['a', 'a']],
                         tagged: {},
                         from: 'x',
                         defaultName: 'x',
@@ -387,8 +409,13 @@ describe(`demos/import-tokenizer`, () => {
                 expectedAst: [
                     createImportValue({
                         star: false,
-                        named: {},
-                        tagged: { named: { a: 'b', c: 'c' } },
+                        named: [],
+                        tagged: {
+                            named: [
+                                ['a', 'b'],
+                                ['c', 'c'],
+                            ],
+                        },
                         from: 'x',
                         defaultName: undefined,
                         errors: [],
@@ -403,8 +430,13 @@ describe(`demos/import-tokenizer`, () => {
                 expectedAst: [
                     createImportValue({
                         star: false,
-                        named: {},
-                        tagged: { ',': { a: 'b', c: 'c' } },
+                        named: [],
+                        tagged: {
+                            ',': [
+                                ['a', 'b'],
+                                ['c', 'c'],
+                            ],
+                        },
                         from: 'x',
                         defaultName: undefined,
                         errors: ['invalid tag name: ,'],
@@ -419,8 +451,13 @@ describe(`demos/import-tokenizer`, () => {
                 expectedAst: [
                     createImportValue({
                         star: false,
-                        named: {},
-                        tagged: { named: { a: 'b', c: 'c' } },
+                        named: [],
+                        tagged: {
+                            named: [
+                                ['a', 'b'],
+                                ['c', 'c'],
+                            ],
+                        },
                         from: 'x',
                         defaultName: undefined,
                         errors: ['unclosed tagged import "named"'],
@@ -435,10 +472,8 @@ describe(`demos/import-tokenizer`, () => {
                 expectedAst: [
                     createImportValue({
                         star: false,
-                        named: {
-                            c: 'c',
-                        },
-                        tagged: { tag1: { a: 'a' }, tag2: { b: 'b' } },
+                        named: [['c', 'c']],
+                        tagged: { tag1: [['a', 'a']], tag2: [['b', 'b']] },
                         from: 'x',
                         defaultName: undefined,
                         errors: [],


### PR DESCRIPTION
This PR fix an issue with named imports overriding each other in case of 2 with identical origin name (for example: `import [x, x as y] from 'abc'` ). This resolves #256 .

**This PR is a breaking change** as it changes the `ImportValue` interface `named` and `tagged` fields from containing a map from "origin to local" to a "list of tuples with from and to":

```ts
// old
interface ImportValue {
  named: Record<string, string> | undefined;
  tagged: Record<string, Record<string, string>> | undefined;
  ...
}

// new
type NamedMapping = [from: string, to: string];
interface ImportValue {
  named: NamedMapping[] | undefined;
  tagged: Record<string, NamedMapping[] | undefined>;
  ...
}
```