### PR TITLE
fix(selector-parser): lost of first non space of a descendant combinator

### DIFF
--- a/packages/css-selector-parser/src/helpers.ts
+++ b/packages/css-selector-parser/src/helpers.ts
@@ -43,7 +43,7 @@ export function createCombinatorAst({
     return {
         type: `combinator`,
         combinator: type,
-        value: type === `space` ? ` ` : value,
+        value: type === `space` ? value[0] : value,
         start,
         end,
         before: ``,

--- a/packages/css-selector-parser/test/selector-parser.spec.ts
+++ b/packages/css-selector-parser/test/selector-parser.spec.ts
@@ -3477,6 +3477,76 @@ describe(`selector-parser`, () => {
             });
         });
     });
+    describe('multiline', () => {
+        it(`.a\n \n.b`, () => {
+            test(`.a\n \n.b`, {
+                expectedAst: [
+                    createNode({
+                        type: `selector`,
+                        start: 0,
+                        end: 7,
+                        nodes: [
+                            createNode({
+                                type: `class`,
+                                value: `a`,
+                                start: 0,
+                                end: 2,
+                            }),
+                            createNode({
+                                type: `combinator`,
+                                combinator: `space`,
+                                value: `\n`,
+                                start: 2,
+                                end: 5,
+                                before: '',
+                                after: ' \n',
+                            }),
+                            createNode({
+                                type: `class`,
+                                value: `b`,
+                                start: 5,
+                                end: 7,
+                            }),
+                        ],
+                    }),
+                ],
+            });
+        });
+        it(`.a\n+\n.b`, () => {
+            test(`.a\n+\n.b`, {
+                expectedAst: [
+                    createNode({
+                        type: `selector`,
+                        start: 0,
+                        end: 7,
+                        nodes: [
+                            createNode({
+                                type: `class`,
+                                value: `a`,
+                                start: 0,
+                                end: 2,
+                            }),
+                            createNode({
+                                type: `combinator`,
+                                combinator: `+`,
+                                value: `+`,
+                                start: 2,
+                                end: 5,
+                                before: '\n',
+                                after: '\n',
+                            }),
+                            createNode({
+                                type: `class`,
+                                value: `b`,
+                                start: 5,
+                                end: 7,
+                            }),
+                        ],
+                    }),
+                ],
+            });
+        });
+    });
     describe(`config`, () => {
         describe(`offset`, () => {
             it(`should start from a given offset`, () => {


### PR DESCRIPTION
This PR fixes an issue for descendant selectors that start with a non space character, like newline.

Before this fix the combinator node would be build with with a `space character as the value` and `after that includes any additional characters after the first one`.  

for example:

```css
.a/*newline+space+newline*/

.b {}
```

would output a descendant combinator with {value: ` `, after: ` \n` }, losing the initial newline.