### PR TITLE
fix: place preferred char in space token

### DIFF
--- a/packages/css-value-parser/src/value-parser.ts
+++ b/packages/css-value-parser/src/value-parser.ts
@@ -50,12 +50,18 @@ function handleToken(
 ): void {
     const { type, value, start, end } = token;
     if (type === `space`) {
-        const firstSpace = value.indexOf(` `);
+        let firstSpace = value.indexOf(` `);
+        if (firstSpace === -1) {
+            firstSpace = value.indexOf(`\n`);
+        }
+        if (firstSpace === -1) {
+            firstSpace = value.indexOf(`\t`);
+        }
         const before = firstSpace !== -1 ? value.substring(0, firstSpace) : ``;
         const after = firstSpace !== -1 ? value.substring(firstSpace + 1) : value.substring(1);
         ast.push(
             space({
-                value: firstSpace !== -1 ? ` ` : value[0],
+                value: firstSpace !== -1 ? value[firstSpace] : value[0],
                 start,
                 end,
                 before,

--- a/packages/css-value-parser/test/value-parser.spec.ts
+++ b/packages/css-value-parser/test/value-parser.spec.ts
@@ -63,6 +63,16 @@ describe(`value-parser`, () => {
                     }),
                 ],
             },
+            {
+                type: `\\r\\n`,
+                source: `\r\n`,
+                expected: [space({ value: `\n`, before: '\r', start: 0, end: 2 })],
+            },
+            {
+                type: `\\r\\t`,
+                source: `\r\t`,
+                expected: [space({ value: `\t`, before: '\r', start: 0, end: 2 })],
+            },
         ].forEach(createTest);
     });
     describe(`literals`, () => {


### PR DESCRIPTION
This PR fixes #122 that claims that `\r\n` takes just the `\r` into the space token value.

The case is a little different. The space token takes only a single char into the value and breaks the rest of the whitespace to `before` and `after`. It used to search for normal space, and fallback to the first character. Now it looks for normal space and falls back to `\n` and then `\t` and only then picks the first character.

This is done presumably to help code formatting, but seems unnecessary to me. I change this in order to close the issue, but would prefer removing he `before` and `after altogether at some point.