### PR TITLE
feat!: use package "exports" instead of "main"

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,8 +2,11 @@
   "name": "@tokey/core",
   "description": "simple code like tokenizer",
   "version": "1.4.0",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./helpers": "./dist/helpers.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "mocha \"./dist/test/**/*.spec.js\""
   },

--- a/packages/core/test/core.spec.ts
+++ b/packages/core/test/core.spec.ts
@@ -7,7 +7,7 @@ import {
     getJSCommentStartType,
     isCommentEnd,
     getUnclosedComment,
-} from '@tokey/core/dist/helpers';
+} from '@tokey/core/helpers';
 import type { Token } from '@tokey/core';
 
 const options: TokyOptions<Token> = {

--- a/packages/core/test/helpers/trim-tokens.spec.ts
+++ b/packages/core/test/helpers/trim-tokens.spec.ts
@@ -1,5 +1,5 @@
 import { testTokenizer as test } from '@tokey/test-kit';
-import { trimTokens } from '@tokey/core/dist/helpers';
+import { trimTokens } from '@tokey/core/helpers';
 import type { Token } from '@tokey/core';
 
 const trimSpace = (tokens: Token[]) => trimTokens(tokens, (token) => token.type === 'space');

--- a/packages/css-selector-parser/package.json
+++ b/packages/css-selector-parser/package.json
@@ -2,8 +2,10 @@
   "name": "@tokey/css-selector-parser",
   "description": "selector parser for css",
   "version": "0.6.2",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "mocha \"./dist/test/**/*.spec.js\""
   },

--- a/packages/css-value-parser/package.json
+++ b/packages/css-value-parser/package.json
@@ -2,8 +2,11 @@
   "name": "@tokey/css-value-parser",
   "description": "value parser for css",
   "version": "0.1.4",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./value-syntax-parser": "./dist/value-syntax-parser.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "mocha \"./dist/test/**/*.spec.js\""
   },

--- a/packages/css-value-parser/test/css-value-syntax.spec.ts
+++ b/packages/css-value-parser/test/css-value-syntax.spec.ts
@@ -11,7 +11,7 @@ import {
     keyword,
     literal,
     property,
-} from '@tokey/css-value-parser/dist/value-syntax-parser';
+} from '@tokey/css-value-parser/value-syntax-parser';
 
 import * as webCssRef from '@webref/css';
 

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -3,8 +3,10 @@
   "name": "@tokey/experiments",
   "description": "experimental tokenizers and parsers",
   "version": "0.1.0",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "mocha \"./dist/test/**/*.spec.js\""
   },

--- a/packages/imports-parser/package.json
+++ b/packages/imports-parser/package.json
@@ -2,8 +2,10 @@
   "name": "@tokey/imports-parser",
   "description": "parser for esm like imports",
   "version": "1.0.0",
-  "main": "dist/imports-parser.js",
-  "types": "dist/imports-parser.d.ts",
+  "exports": {
+    ".": "./dist/imports-parser.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "mocha \"./dist/test/**/*.spec.js\""
   },

--- a/packages/test-kit/package.json
+++ b/packages/test-kit/package.json
@@ -3,8 +3,10 @@
   "private": true,
   "description": "test kit to test parsers and ast",
   "version": "1.2.0",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {},
   "files": [
     "src",

--- a/packages/test-kit/src/index.ts
+++ b/packages/test-kit/src/index.ts
@@ -1,3 +1,3 @@
-export { createParseTester } from './parse-tester';
+export { createParseTester, type TestOptions, type TesterConfig } from './parse-tester';
 export { testTokenizer } from './test-tokenizer';
 export { isMatch } from './is-match';

--- a/packages/url-tokenizer/package.json
+++ b/packages/url-tokenizer/package.json
@@ -2,8 +2,10 @@
   "name": "@tokey/url-tokenizer",
   "description": "tokenize css url() syntax",
   "version": "0.1.0",
-  "main": "dist/url-tokenizer.js",
-  "types": "dist/url-tokenizer.d.ts",
+  "exports": {
+    ".": "./dist/url-tokenizer.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "mocha \"./dist/test/**/*.spec.js\""
   },


### PR DESCRIPTION
to avoid everything being public by default

had to open two extra entrypoints for unit tests. can be removed one we move "test" folder into "src"